### PR TITLE
月間の人気度合いを把握したいため、月間グラフの描画を追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from utils.db import init_db
 from utils.common import get_date_from_params
-from pages import top, survey, vote, result, stock_master, db_management
+from pages import top, survey, vote, result, result_graph, stock_master, db_management
 
 # DB初期化
 init_db()
@@ -23,6 +23,7 @@ st.sidebar.markdown(f'<a href="./?page=top&date={date_str}" target="_self">ト�
 st.sidebar.markdown(f'<a href="./?page=survey&date={date_str}" target="_self">① 銘柄コード登録</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=vote&date={date_str}" target="_self">② 銘柄投票</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=result&date={date_str}" target="_self">③ 投票結果確認</a>', unsafe_allow_html=True)
+st.sidebar.markdown(f'<a href="./?page=result_graph&date={date_str}" target="_self">④ 投票結果の推移</a>', unsafe_allow_html=True)
 st.sidebar.markdown("---")
 st.sidebar.markdown(f'<a href="./?page=stock_master&date={date_str}" target="_self">銘柄マスタ管理</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=db_management&date={date_str}" target="_self">データベース管理</a>', unsafe_allow_html=True)
@@ -38,5 +39,7 @@ elif page == 'vote':
     vote.show(selected_date)
 elif page == 'result':
     result.show(selected_date)
+elif page == 'result_graph':
+    result_graph.show(selected_date)
 else:
     top.show(selected_date)

--- a/pages/result_graph.py
+++ b/pages/result_graph.py
@@ -1,0 +1,120 @@
+#coding: utf_8
+import streamlit as st
+import re
+from utils.db import get_connection
+
+def show(selected_date):
+    selected_month_str = selected_date.strftime("%Y-%m")
+
+    st.title("投票結果の推移")
+    st.write(f"【投票月】{selected_month_str}")
+
+    # REGEXPを使うための関数を定義
+    def regexp(pattern, string):
+      return bool(re.match(pattern, string))
+    
+    # voteテーブルから、各投票回の投票数を取得する
+    conn = get_connection()
+
+    # REGEXP関数をSQLiteに登録
+    conn.create_function('REGEXP', 2, regexp)
+
+    # 日本株 (数字始まり)
+    c = conn.cursor()
+    c.execute(
+        """
+        SELECT vote_date,stock_code,count(stock_code) AS vote_count
+         FROM vote WHERE vote_date LIKE ? AND stock_code REGEXP '^[0-9]+'
+         GROUP BY vote_date, stock_code;
+        """,
+        (selected_month_str + '-%',)
+    )
+    results_jp = c.fetchall()
+
+    # 米国株 (英字始まり)
+    c = conn.cursor()
+    c.execute(
+        """
+        SELECT vote_date,stock_code,count(stock_code) AS vote_count
+         FROM vote WHERE vote_date LIKE ? AND stock_code REGEXP '^[A-Z]+'
+         GROUP BY vote_date, stock_code;
+        """,
+        (selected_month_str + '-%',)
+    )
+    results_us = c.fetchall()
+
+    conn.close()
+
+    if results_jp or results_us:
+        # グラフ表示
+        try:
+            import matplotlib
+            import plotly.graph_objects as go
+            import pandas as pd
+            import datetime
+
+            # 投票結果をキャッシュキーとして使用
+            @st.cache_data(ttl=None)  # TTLなし（投票結果が変わるまでキャッシュ有効）
+            def generate_votegraph(kinds, vote_results):
+
+                # DataFrameに変換
+                df = pd.DataFrame(vote_results, columns=["日付", "銘柄コード", "投票数"])
+                df["日付"] = pd.to_datetime(df["日付"])  # 日付をDatetime型に変換
+
+                # 投票推移を線で結んだ折線グラフを準備する
+                # 銘柄コードごとにデータを整理
+                fig = go.Figure()
+                for stock_code in sorted(df["銘柄コード"].unique()):
+                    stock_data = df[df["銘柄コード"] == stock_code]
+
+                    # 日付毎に描画する
+                    stock_data = stock_data.sort_values(by="日付")
+                    fig.add_trace(go.Scatter(
+                        x=stock_data["日付"],
+                        y=stock_data["投票数"],
+                        mode='lines+markers',  # 線とマーカーを両方表示
+                        name=f'{stock_code}',
+                        hovertemplate='%{y}'
+                    ))
+
+                # 標準だとフォントが小さいので少しだけ大きくする
+                fontsize=dict(size=16)
+
+                # X軸の形式を "YYYY-MM-DD" に設定
+                fig.update_xaxes(tickformat="%Y-%m-%d", tickfont=fontsize)
+
+                # Y軸の最小値を0に設定
+                fig.update_yaxes(range=[0, df["投票数"].max() + 5], tickfont=fontsize)  # 上限は少し余裕を持たせる
+
+                # グラフのレイアウト設定
+                fig.update_layout(
+                    title= kinds,
+                    xaxis_title="日付",
+                    yaxis_title="投票数",
+                    legend_title="銘柄コード",
+                    template="plotly_dark",
+                    legend=dict(font=fontsize),     # 凡例のフォントサイズ
+                    hoverlabel=dict(font=fontsize), # グラフの値のフォントサイズ
+                    width=1000,                     # グラフ本体(幅)
+                    height=600                      # グラフ本体(高さ)
+                )
+
+                return fig
+            
+            # 投票データを文字列化してキャッシュキーとして使用
+            vote_data_str = str(results_jp + results_us)
+
+            # 日本株描画
+            fig = generate_votegraph('日本株', results_jp)
+            st.plotly_chart(fig)
+
+            # 米国株描画
+            fig = generate_votegraph('米国株', results_us)
+            st.plotly_chart(fig)
+
+            
+        except ImportError:
+            st.error("matplotlib, pandas, pandas, datetime ライブラリが必要です。'pip3 install matplotlib, pandas, pandas, datetime'でインストールしてください。")
+
+    else:
+        st.write("対象日の投票結果はまだありません。") 

--- a/pages/result_graph.py
+++ b/pages/result_graph.py
@@ -11,8 +11,8 @@ def show(selected_date):
 
     # REGEXPを使うための関数を定義
     def regexp(pattern, string):
-      return bool(re.match(pattern, string))
-    
+        return bool(re.match(pattern, string))
+
     # voteテーブルから、各投票回の投票数を取得する
     conn = get_connection()
 
@@ -100,7 +100,7 @@ def show(selected_date):
                 )
 
                 return fig
-            
+
             # 投票データを文字列化してキャッシュキーとして使用
             vote_data_str = str(results_jp + results_us)
 
@@ -112,9 +112,8 @@ def show(selected_date):
             fig = generate_votegraph('米国株', results_us)
             st.plotly_chart(fig)
 
-            
         except ImportError:
-            st.error("matplotlib, pandas, pandas, datetime ライブラリが必要です。'pip3 install matplotlib, pandas, pandas, datetime'でインストールしてください。")
+            st.error("matplotlib, plotly, pandas ライブラリが必要です。'pip3 install matplotlib, plotly, pandas'でインストールしてください。")
 
     else:
         st.write("対象日の投票結果はまだありません。") 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ matplotlib
 pandas
 openpyxl
 plotly
-datetime
-re

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ wordcloud
 matplotlib
 pandas
 openpyxl
+plotly
+datetime
+re


### PR DESCRIPTION
## 目的
銘柄投票を行なっているため、それぞれの銘柄の人気の傾向を把握したい。

## 概要
簡単な方法として折線グラフを線で繋ぐのが手っ取り早いので実装してみます。

## 変更内容
* 「投票結果の推移」ページの新規追加
投票月の結果の推移になるため、投票結果と時間軸が変わるため新規ページにしました。
** 人気度合いの把握をしやすくするために、折れ線グラフにしてみました。
** 凡例を銘柄コード順にしてクリックしやすくしています。
** 相場毎に傾向が変わると思いますので、日本株と米国株でグラフ分けしてみました。

* 左メニュー「④ 投票結果の推移」の追加
→ リンクの追加


## スクリーンショット
2025.2の表示例
<img width="1391" alt="image" src="https://github.com/user-attachments/assets/16b372d8-7b88-4070-b01b-bbda9c4a1a2a" />

個別の拡大画面
<img width="1326" alt="image" src="https://github.com/user-attachments/assets/a4c8f7ff-12f8-4c2b-9658-58b1ceff3fdb" />

補足
動作確認環境
* MacOS 15.3.1
* Python 3.9.6 (MacOS標準)
* 開発環境は VS Code