### PR TITLE
「投票結果の推移」のグラフ描画をリファクタリングする対応

### DIFF
--- a/pages/result_graph.py
+++ b/pages/result_graph.py
@@ -1,17 +1,28 @@
 #coding: utf_8
 import streamlit as st
+import datetime
 import re
 from utils.db import get_connection
 
+# 取得・表示の最大日数 (DB負荷考慮)
+MAX_DAYS=365
+
 def show(selected_date):
-    selected_month_str = selected_date.strftime("%Y-%m")
+    selected_date_str = selected_date.strftime("%Y-%m-%d")
 
     st.title("投票結果の推移")
-    st.write(f"【投票月】{selected_month_str}")
+    st.write(f"【投票日】{selected_date_str}")
 
     # REGEXPを使うための関数を定義
     def regexp(pattern, string):
         return bool(re.match(pattern, string))
+
+    sql_template = """
+        SELECT vote_date, stock_code, count(stock_code) AS vote_count
+         FROM vote WHERE vote_date BETWEEN ? AND ? 
+         AND stock_code REGEXP ?
+         GROUP BY vote_date, stock_code;
+    """
 
     # voteテーブルから、各投票回の投票数を取得する
     conn = get_connection()
@@ -22,98 +33,70 @@ def show(selected_date):
     # 日本株 (数字始まり)
     c = conn.cursor()
     c.execute(
-        """
-        SELECT vote_date,stock_code,count(stock_code) AS vote_count
-         FROM vote WHERE vote_date LIKE ? AND stock_code REGEXP '^[0-9]+'
-         GROUP BY vote_date, stock_code;
-        """,
-        (selected_month_str + '-%',)
+        sql_template,
+        ((selected_date - datetime.timedelta(days=MAX_DAYS)).strftime("%Y-%m-%d"),
+         selected_date_str,
+         "^[0-9]+"
+        )
     )
     results_jp = c.fetchall()
 
     # 米国株 (英字始まり)
     c = conn.cursor()
     c.execute(
-        """
-        SELECT vote_date,stock_code,count(stock_code) AS vote_count
-         FROM vote WHERE vote_date LIKE ? AND stock_code REGEXP '^[A-Z]+'
-         GROUP BY vote_date, stock_code;
-        """,
-        (selected_month_str + '-%',)
+        sql_template,
+        ((selected_date - datetime.timedelta(days=MAX_DAYS)).strftime("%Y-%m-%d"),
+         selected_date_str,
+         "^[A-Z]+"
+        )
     )
     results_us = c.fetchall()
-
     conn.close()
 
     if results_jp or results_us:
         # グラフ表示
         try:
             import matplotlib
-            import plotly.graph_objects as go
             import pandas as pd
-            import datetime
 
             # 投票結果をキャッシュキーとして使用
             @st.cache_data(ttl=None)  # TTLなし（投票結果が変わるまでキャッシュ有効）
-            def generate_votegraph(kinds, vote_results):
 
-                # DataFrameに変換
+            # DataFrameに変換
+            def convert_to_df(vote_results):
                 df = pd.DataFrame(vote_results, columns=["日付", "銘柄コード", "投票数"])
                 df["日付"] = pd.to_datetime(df["日付"])  # 日付をDatetime型に変換
+                return df
 
-                # 投票推移を線で結んだ折線グラフを準備する
-                # 銘柄コードごとにデータを整理
-                fig = go.Figure()
-                for stock_code in sorted(df["銘柄コード"].unique()):
-                    stock_data = df[df["銘柄コード"] == stock_code]
+            # スライダーで日付範囲を選択
+            dates = pd.date_range(start = (selected_date - datetime.timedelta(days=MAX_DAYS)).strftime("%Y-%m-%d"), end = selected_date_str, freq = "D")
+            start_date = st.slider("開始日", min_value = dates.min().to_pydatetime(), max_value = dates.max().to_pydatetime(), value = dates.min().to_pydatetime(), key="slider_min")
+            end_date   = st.slider("終了日", min_value = dates.min().to_pydatetime(), max_value = dates.max().to_pydatetime(), value = dates.max().to_pydatetime(), key="slider_max")
 
-                    # 日付毎に描画する
-                    stock_data = stock_data.sort_values(by="日付")
-                    fig.add_trace(go.Scatter(
-                        x=stock_data["日付"],
-                        y=stock_data["投票数"],
-                        mode='lines+markers',  # 線とマーカーを両方表示
-                        name=f'{stock_code}',
-                        hovertemplate='%{y}'
-                    ))
+            result_list = [
+                {"result_key": "日本株", "result_value": results_jp},
+                {"result_key": "米国株", "result_value": results_us}
+            ]
 
-                # 標準だとフォントが小さいので少しだけ大きくする
-                fontsize=dict(size=16)
+            df = None
+            for result in result_list:
+                st.subheader(result["result_key"])
+                df = convert_to_df(result["result_value"])
+                filtered_df = df[(df["日付"] >= pd.to_datetime(start_date)) & (df["日付"] <= pd.to_datetime(end_date))]
+                filtered_df["日付"] = filtered_df["日付"].dt.strftime("%m月%d日") # 日付の表示形式変換
 
-                # X軸の形式を "YYYY-MM-DD" に設定
-                fig.update_xaxes(tickformat="%Y-%m-%d", tickfont=fontsize)
+                options = st.multiselect("銘柄コードを選択してください:", sorted(df["銘柄コード"].unique().tolist()), default=[])
+                if options:
+                     # 銘柄コードがない日付に NaN（欠損値）を入れる対応
+                     df_pivot = filtered_df.pivot(index="日付", columns="銘柄コード", values="投票数")
+                     df_selected = df_pivot.reindex(columns=options)  # 存在しない場合は NaN になる
+                     st.line_chart(df_selected, use_container_width=True)
 
-                # Y軸の最小値を0に設定
-                fig.update_yaxes(range=[0, df["投票数"].max() + 5], tickfont=fontsize)  # 上限は少し余裕を持たせる
-
-                # グラフのレイアウト設定
-                fig.update_layout(
-                    title= kinds,
-                    xaxis_title="日付",
-                    yaxis_title="投票数",
-                    legend_title="銘柄コード",
-                    template="plotly_dark",
-                    legend=dict(font=fontsize),     # 凡例のフォントサイズ
-                    hoverlabel=dict(font=fontsize), # グラフの値のフォントサイズ
-                    width=1000,                     # グラフ本体(幅)
-                    height=600                      # グラフ本体(高さ)
-                )
-
-                return fig
-
-            # 投票データを文字列化してキャッシュキーとして使用
-            vote_data_str = str(results_jp + results_us)
-
-            # 日本株描画
-            fig = generate_votegraph('日本株', results_jp)
-            st.plotly_chart(fig)
-
-            # 米国株描画
-            fig = generate_votegraph('米国株', results_us)
-            st.plotly_chart(fig)
+                else:
+                    st.line_chart(filtered_df, x="日付", y="投票数", color="銘柄コード", use_container_width=True)
 
         except ImportError:
-            st.error("matplotlib, plotly, pandas ライブラリが必要です。'pip3 install matplotlib, plotly, pandas'でインストールしてください。")
+            st.error("matplotlib, pandas ライブラリが必要です。'pip3 install matplotlib, pandas'でインストールしてください。")
 
     else:
-        st.write("対象日の投票結果はまだありません。") 
+        st.write("対象日の投票結果はまだありません。")

--- a/pages/top.py
+++ b/pages/top.py
@@ -11,7 +11,7 @@ def show(selected_date):
     st.markdown("---")
     st.subheader("各ページへのリンク")
     
-    col1, col2, col3 = st.columns(3)
+    col1, col2, col3, col4 = st.columns(4)
     
     with col1:
         st.markdown(f'<a href="./?page=survey&date={date_str}" target="_self">銘柄コード登録</a>', unsafe_allow_html=True)
@@ -24,3 +24,7 @@ def show(selected_date):
     with col3:
         st.markdown(f'<a href="./?page=result&date={date_str}" target="_self">投票結果確認</a>', unsafe_allow_html=True)
         st.write("投票結果を確認します") 
+
+    with col4:
+        st.markdown(f'<a href="./?page=result_graph&date={date_str}" target="_self">投票結果の推移</a>', unsafe_allow_html=True)
+        st.write("投票結果の推移を確認します") 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ wordcloud
 matplotlib
 pandas
 openpyxl
-plotly


### PR DESCRIPTION
## 目的
https://github.com/kita-develop/discover-stocks/pull/1
の使い勝手の見直し。（リファクタリング）

## 概要
先日作成した「投票結果の推移」を使用感として `plotly_chart` だとグラフの拡大や期間変更などしづらそうに見えたので、
通常の折線グラフ `line_chart` 変更して使いやすくします。

## 変更内容
* 「投票結果の推移」ページの修正
DBから取得する最大日数を設定（ひとまず365日）
→ 今までは月を跨ぐとグラフが初期化されてしまう実装でした。
月跨ぎに対応するため、過去365日を表示する実装にしました。

* グラフの描画修正
→ `plotly_chart` を利用していた頃は凡例が全て出ており銘柄選択が出来ていたのですが、 `line_chart` だとそれが出来ない様でした。
銘柄を部分的に選べる様に `st.multiselect` を入れて補完するようにしました。

* トップページへ「④ 投票結果の推移」の追加
→ リンクの追加


## スクリーンショット
### パターン1
デフォルト表示
<img width="808" alt="image" src="https://github.com/user-attachments/assets/cbff400e-afad-4171-b7c9-a3313e10cfee" />

### パターン2
銘柄選択時
<img width="754" alt="image" src="https://github.com/user-attachments/assets/7aba32e2-a1be-4a4f-a145-a5515bbd7a49" />

### パターン3
期間選択時
<img width="785" alt="image" src="https://github.com/user-attachments/assets/ecec0d7b-e1d9-4abb-89f2-126d5d6ea615" />
