### PR TITLE
票数の区切りを追加してExportする機能を追加

### DIFF
--- a/pages/result.py
+++ b/pages/result.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from utils.common import format_vote_data_with_thresh
 from utils.db import get_connection
 import csv
 from io import StringIO
@@ -29,11 +30,19 @@ def show(selected_date):
     conn.close()
     
     if results:
+        row1_col1, row1_col2 = st.columns(2)
         # テキストファイルExportボタン
         codes = [row[0] for row in results]
         file_content = "\n".join(codes)
         filename = f"投票結果{selected_date.strftime('%Y%m%d')}.txt"
-        st.download_button("銘柄コードExport", data=file_content, file_name=filename, mime="text/plain")
+        with row1_col1:
+            st.download_button("銘柄コードExport", data=file_content, file_name=filename, mime="text/plain")
+
+        sorted_results_with_thresh = format_vote_data_with_thresh(results)
+        if sorted_results_with_thresh:
+            filename = f"投票結果{selected_date.strftime('%Y%m%d')}_票数付.txt"
+            with row1_col2:
+                st.download_button("銘柄コードExport(票数付)", data=sorted_results_with_thresh, file_name=filename, mime="text/plain")
         
         # CSVファイルExportボタン
         csv_buffer = StringIO()

--- a/pages/result.py
+++ b/pages/result.py
@@ -44,6 +44,7 @@ def show(selected_date):
             with row1_col2:
                 st.download_button("銘柄コードExport(票数付)", data=sorted_results_with_thresh, file_name=filename, mime="text/plain")
         
+        row2_col1, row2_col2 = st.columns(2)
         # CSVファイルExportボタン
         csv_buffer = StringIO()
         csv_writer = csv.writer(csv_buffer)
@@ -60,12 +61,13 @@ def show(selected_date):
         csv_bytes = csv_str.encode('shift-jis', errors='replace')
         
         csv_filename = f"投票結果{selected_date.strftime('%Y%m%d')}.csv"
-        st.download_button(
-            "投票結果CSV Export",
-            data=csv_bytes,
-            file_name=csv_filename,
-            mime="text/csv"
-        )
+        with row2_col1:
+            st.download_button(
+                "投票結果CSV Export",
+                data=csv_bytes,
+                file_name=csv_filename,
+                mime="text/csv"
+            )
         
         # Excelファイルのエクスポート
         excel_filename = f"投票結果{selected_date.strftime('%Y%m%d')}.xlsx"
@@ -99,13 +101,13 @@ def show(selected_date):
                 cell.style = 'Hyperlink'
         
         excel_data = excel_buffer.getvalue()
-        
-        st.download_button(
-            "投票結果Excel Export",
-            data=excel_data,
-            file_name=excel_filename,
-            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        )
+        with row2_col2:
+            st.download_button(
+                "投票結果Excel Export",
+                data=excel_data,
+                file_name=excel_filename,
+                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
         
         st.markdown("---")
 

--- a/pages/vote.py
+++ b/pages/vote.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from datetime import datetime
 from utils.db import get_connection
-from utils.common import MAX_VOTE_SELECTION
+from utils.common import MAX_VOTE_SELECTION, format_vote_data_with_thresh
 import csv
 from io import StringIO
 import pandas as pd
@@ -35,15 +35,24 @@ def show(selected_date):
         if sort_option == "銘柄コード 昇順":
             sorted_results = sorted(results, key=lambda x: x[0])
             sort_suffix = "_コード順"
+            sorted_results_with_thresh = None
         else:
             sorted_results = sorted(results, key=lambda x: x[1], reverse=True)
             sort_suffix = "_票数順"
+            sorted_results_with_thresh = format_vote_data_with_thresh(results)
         
+        row1_col1, row1_col2 = st.columns(2)
         # テキストファイルExportボタン
         codes = [row[0] for row in sorted_results]
         file_content = "\n".join(codes)
         filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}{sort_suffix}.txt"
-        st.download_button("銘柄コードExport", data=file_content, file_name=filename, mime="text/plain")
+        with row1_col1:
+            st.download_button("銘柄コードExport", data=file_content, file_name=filename, mime="text/plain")
+
+        if sorted_results_with_thresh:
+            with row1_col2:
+                filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}{sort_suffix}_票数付.txt"
+                st.download_button("銘柄コードExport(票数付)", data=sorted_results_with_thresh, file_name=filename, mime="text/plain")
         
         # CSVファイルExportボタン
         csv_buffer = StringIO()

--- a/pages/vote.py
+++ b/pages/vote.py
@@ -54,6 +54,7 @@ def show(selected_date):
                 filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}{sort_suffix}_票数付.txt"
                 st.download_button("銘柄コードExport(票数付)", data=sorted_results_with_thresh, file_name=filename, mime="text/plain")
         
+        row2_col1, row2_col2 = st.columns(2)
         # CSVファイルExportボタン
         csv_buffer = StringIO()
         csv_writer = csv.writer(csv_buffer)
@@ -70,12 +71,13 @@ def show(selected_date):
         csv_bytes = csv_str.encode('shift-jis', errors='replace')
         
         csv_filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}{sort_suffix}.csv"
-        st.download_button(
-            "集計結果CSV Export",
-            data=csv_bytes,
-            file_name=csv_filename,
-            mime="text/csv"
-        )
+        with row2_col1:
+            st.download_button(
+                "集計結果CSV Export",
+                data=csv_bytes,
+                file_name=csv_filename,
+                mime="text/csv"
+            )
         
         # Excelファイルのエクスポート
         excel_filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}{sort_suffix}.xlsx"
@@ -109,13 +111,13 @@ def show(selected_date):
                 cell.style = 'Hyperlink'
         
         excel_data = excel_buffer.getvalue()
-        
-        st.download_button(
-            "集計結果Excel Export",
-            data=excel_data,
-            file_name=excel_filename,
-            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        )
+        with row2_col2:
+            st.download_button(
+                "集計結果Excel Export",
+                data=excel_data,
+                file_name=excel_filename,
+                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
         
         # 投票方法の説明
         st.info("""

--- a/utils/common.py
+++ b/utils/common.py
@@ -11,4 +11,50 @@ def get_date_from_params(query_params):
             return datetime.strptime(date_param, "%Y%m%d").date()
         except ValueError:
             return date.today()
-    return date.today() 
+    return date.today()
+
+
+THRESHOLDS=[100, 50, 30, 20, 10, 5]
+def format_vote_data_with_thresh(vote_data):
+    """
+    投票データを閾値に基づいて区切り（###）を入れて銘柄コードをリストにする
+    範囲表示形式（例：100～、50～99）で区切りを表示
+
+    Parameters:
+    vote_data (list): [銘柄コード(row[0]), 投票数(row[1])] の形式のリスト
+
+    Returns:
+    str: 区切り（###）と銘柄コードを改行コードでつないだ文字列
+    """
+    thresholds = sorted(THRESHOLDS, reverse=True) # 念のため区切りを降順にする
+    sorted_data = sorted(vote_data, key=lambda row: row[1], reverse=True) # 念のためデータを票数の降順にする
+
+    result = []
+    # 各閾値ごとにデータを処理
+    for i, threshold in enumerate(thresholds):
+        # 範囲表示のラベルを作成
+        if i == 0:
+            # 最大閾値の場合は「100～」のような表示
+            range_label = f"###{threshold}～"
+        else:
+            # その他の閾値の場合は「50～99」のような表示
+            upper_limit = thresholds[i-1] - 1
+            range_label = f"###{threshold}～{upper_limit}"
+
+        result.append(range_label)
+
+        # この閾値以上の投票数を持つキーを追加
+        next_threshold = thresholds[i-1] if i > 0 else float('inf')
+
+        keys_in_range = [row[0] for row in sorted_data
+                         if row[1] >= threshold and row[1] < next_threshold]
+        result.extend(keys_in_range)
+
+    # 最小閾値以下のデータを処理
+    min_threshold = thresholds[-1]
+    result.append(f"###～{min_threshold-1}")
+
+    keys_below_min = [row[0] for row in sorted_data if row[1] < min_threshold]
+    result.extend(keys_below_min)
+
+    return '\n'.join(result)


### PR DESCRIPTION
- 「銘柄コードExport(票数付)」ボタンを追加しました。TradingViewにインポートするときに大体の票数が分かるように区切りを入れています。
　区切りの閾値（THRESHOLDS）は暫定ですので必要に応じてあとで調整する想定です。
- 「銘柄投票」ページの、「銘柄コード昇順」の時には、上記ボタンは表示しません。「アンケート票数 降順」のときに表示します。
- 上記の修正に伴いボタンの配置を以下のように2x2に変えています。
[銘柄コードExport] [銘柄コードExport(票数付)]
[投票結果csv] [投票結果Excel Export]
ボタンの配置変更がマズい場合は、以下のコミットをrevertしていただいて構いません。
b5170ddcc8acfc799d96199d73c832e816fbda3a