### PR TITLE
パフォーマンス改善 SQLiteのジャーナルモードをWAL, 同期モードをNORMALへ変更する

### DIFF
--- a/pages/db_management.py
+++ b/pages/db_management.py
@@ -9,13 +9,16 @@ from utils.db import get_connection
 def show(selected_date):
     st.title("データベース管理")
     
-    tab1, tab2 = st.tabs(["エクスポート", "インポート"])
+    tab1, tab2, tab3 = st.tabs(["エクスポート", "インポート", "データベース整理"])
     
     with tab1:
         show_export()
     
     with tab2:
         show_import()
+
+    with tab3:
+        show_wal_checkpoint()
 
 def show_export():
     st.subheader("データベースエクスポート")
@@ -125,3 +128,25 @@ def show_import():
                         
         except Exception as e:
             st.error(f"ファイルの読み込みに失敗しました: {str(e)}") 
+
+def show_wal_checkpoint():
+    st.subheader("データベース整理")
+
+    # WALチェックポイントを実行する関数
+    def run_wal_checkpoint():
+        conn = get_connection()
+        c = conn.cursor()
+
+        try:
+            c.execute("PRAGMA wal_checkpoint(FULL);")
+
+        except Exception as e:
+            # PRAGMA wal_checkpointはトランザクション外のコマンドのためRollBack不可
+            st.error(f"データベース整理に失敗しました: {str(e)}") 
+
+        finally:
+            conn.close()
+
+    if st.button("データベース整理実行"):
+        run_wal_checkpoint()
+        st.success("データベース整理を実行しました")

--- a/utils/db.py
+++ b/utils/db.py
@@ -14,7 +14,11 @@ def init_db():
     """
     conn = get_connection()
     c = conn.cursor()
-    
+
+    # DB高速化
+    c.execute("PRAGMA journal_mode=WAL;")
+    c.execute("PRAGMA synchronous=NORMAL;")
+
     # 銘柄発掘アンケートの回答保存テーブル
     c.execute(
         """


### PR DESCRIPTION
## 目的
パフォーマンス改善 （暫定）

## 概要
接続数 100名+でトップページの閲覧がしづらい（場合によっては見えない）という問題が発生しています。

実装を確認したところ
トップページ閲覧時に `initdb()` で `CREATE TABLE IF EXISTS` などを実施しているように見えています。
https://github.com/kita-develop/discover-stocks/blob/main/app.py#L7
↓
https://github.com/kita-develop/discover-stocks/blob/main/utils/db.py#L10-L53

このため、トップページ閲覧時にトランザクションを取得して遅くなっているかも？
という仮定の基、トランザクションを軽くしたいと思います。

### トランザクション管理の変更
[SQLite のパフォーマンスに関するベスト プラクティス ](https://developer.android.com/topic/performance/sqlite-performance-best-practices?hl=ja)  
を見て、
* write-ahead log 書き込みを有効化
* 同期モードを緩和する

の対策が手っ取り早く出来そうに見えるので実装します。

意味合いとしては
|Key|Value|Note|
|---|---|---|
|journal_mode| `DELETE -> WAL` |DELETE: トランザクション終了時にロールバックジャーナルを削除する設定<br>↓<br>WAL: ログ先行書き込み（WAL）ということで追記型へ変更 <br>ということでファイルの削除によるファイルロックを減らす。<br>Ref: https://sqlite.org/pragma.html#pragma_journal_mode|
|synchronous| `FULL -> NORMAL`|FULL: commitタイミングで `fsync` 完了まで待つ。<br>↓<br>NORMAL: 重要なタイミングで同期するものの、 FULLモードよりは頻度は少なくなる。<br>（＝レスポンス高速化）<br>かつ、 `WAL mode is safe from corruption with synchronous=NORMAL,... ` ということなので破損からも保護されるとのこと。<br><br>ということなので、クラッシュ時の安全性は若干下がるものの、クラッシュ頻度もそうなさそうなのでパフォーマンスへ若干寄せるイメージです。<br>Ref: https://sqlite.org/pragma.html#pragma_synchronous|

### データベース管理メニューへの追加
上述のWAL モードにするとログ書き込み用に `surbey.db{,-shm,-wal}` の3ファイルが出来るため、
チェックポイント(postgresとかだとvacuumdb相当？)できる様に
 `PRAGMA wal_checkpoint(FULL)` するページを増やしました。

## 効果
パフォーマンスコマンドの `wrk` で、ローカルで試せる程度 (127接続, 127スレッド, 60秒)で試したところ
以下の様に心持ち早くなったかなくらいの感じです。

Requests/sec: +9.3%
```
% echo '4382.06 / 4008.54 * 100' | bc -l
109.31810584402301087100
```

ローカルで試した程度の差分なので、
リリースした際に効果がどの程度出るかは試してみないとなぁという印象です。
（誤差程度の効果だったらスイマセンmm）

変更前
```
% wrk -t127 -c127 -d60s 'http://127.0.0.1:8501/?page=top&date=20250323'
Running 1m test @ http://127.0.0.1:8501/?page=top&date=20250323
  127 threads and 127 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    31.42ms    4.45ms  86.44ms   96.19%
    Req/Sec    31.76      5.29    80.00     69.13%
  240935 requests in 1.00m, 510.79MB read
  Socket errors: connect 1, read 0, write 0, timeout 0
Requests/sec:   4008.54
Transfer/sec:      8.50MB
```
→ `Requests/sec:   4008.54` 

変更後
```
% wrk -t127 -c127 -d60s 'http://127.0.0.1:8501/?page=top&date=20250323'
Running 1m test @ http://127.0.0.1:8501/?page=top&date=20250323
  127 threads and 127 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    28.73ms    2.58ms  61.12ms   96.84%
    Req/Sec    34.76      5.23   181.00     44.77%
  263380 requests in 1.00m, 558.37MB read
  Socket errors: connect 1, read 0, write 0, timeout 0
Requests/sec:   4382.06
Transfer/sec:      9.29MB
```
→ `Requests/sec:   4382.06` 



## スクリーンショット
### WAL変更
→ `survey.db` から3ファイルへ増えたのでモード変更を確認済
```
% ls -al survey.db*
-rw-r--r--  1 ogalush  staff  606208  3 23 05:04 survey.db
-rw-r--r--  1 ogalush  staff   32768  3 23 05:06 survey.db-shm
-rw-r--r--  1 ogalush  staff       0  3 23 05:04 survey.db-wal
```
### データベース整理画面
→ データベース管理画面に「データベース整理」ボタンをつけました。
<img width="752" alt="image" src="https://github.com/user-attachments/assets/c2267435-10b3-4b0b-a565-eea4f6c4ba3d" />

## その他
ChatGPTで調べた感じだと、Streamlit自体が1プロセス1スレッドのフレームワークという風に回答があったので、
おそらくパフォーマンス改善の根本対応は
```
As Is
・StreamLitとDB (Sqlite)が同じインスタンスに乗っている状態
↓
To Be
・StreamLit * 複数インスタンス + DBをSQLite → MySQLへ換装（複数インスタンスで共有できる様に）
・もしくは、マルチスレッド対応フレームワークへの変更（パッと思い浮かばずですが）
```
という感じで、横方向へスケールアウトする構成変更がいるのかなぁ、、という理解をしています。

ただ、そこまでやろうとすると既存からの改修量も多く、趣味というよりも案件対応になってくるのかなととも思ったので、
今できる範囲でということでPRしました。