### PR TITLE
左メニュー上部の「pages」ディレクトリの一覧を非表示にしました。

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,5 @@
+[browser]
+gatherUsageStats = false
+
+[client]
+showSidebarNavigation = false


### PR DESCRIPTION
## 目的
見た目の整理

## 概要
Streamlit本体の設定を `streamlit config show` で確認し、変更可能なパラメータを調整したいと思います。

## 変更内容

### 左メニュー上部の「pages」ディレクトリの一覧を非表示にしました。
左メニューは既に実装済みであるためデフォルト表示を非表示にしました。

Ref: 
https://docs.streamlit.io/develop/api-reference/configuration/config.toml
```
[client]
...(略)...
# Controls whether to display the default sidebar page navigation in a
# multi-page app. This only applies when app's pages are defined by the
# `pages/` directory.
# Default: true
showSidebarNavigation = true
```

### ブラウザからstreamlitコミュニティへ送信する統計情報の抑止
（利用促進を目的に) ブラウザからStreamlitコミュニティへ匿名化された形で統計情報を送る設定がある様です。
UIのパフォーマンス観点やセキュリティ観点で無効化して差し支えないため、ついでに設定しておこうと思います。

Ref: 
https://docs.streamlit.io/develop/api-reference/configuration/config.toml
```
[browser]
...(略)...
# Whether to send usage statistics to Streamlit.
# Default: true
gatherUsageStats = true
```

ChatGPT曰く
```
Q:  gatherUsageStats = true にすると何が嬉しいの？
A: 
gatherUsageStats = true にすることの「嬉しさ」は、主に Streamlit コミュニティや開発チームへの貢献にあります。
...(略)...
gatherUsageStats = true のメリット
1. Streamlit の改善に貢献できる
Streamlit チームは、ユーザーから送信された匿名の利用統計を元に、
• よく使われているバージョン・設定
• 人気のある機能
• 使われていない機能
• クラッシュ状況やエラー傾向
などを分析して、製品をより良くするための判断材料にしています。
たとえば：「多くの人が st.cache を使ってる」→「じゃあ改善しよう！」という流れ。
```
と言うことの様です。

## スクリーンショット
変更前
<img width="726" alt="image" src="https://github.com/user-attachments/assets/7321548b-f82f-4bbc-a8aa-55f6921b67b1" />
↓
変更後
<img width="749" alt="image" src="https://github.com/user-attachments/assets/0018e8c5-f9c3-4a2e-bdb5-5416ce310ea9" />