### PR TITLE
パフォーマンス改善3 統計情報の更新を行いQueryPlanを最適化させる対応

### DIFF
--- a/pages/db_management.py
+++ b/pages/db_management.py
@@ -18,7 +18,7 @@ def show(selected_date):
         show_import()
 
     with tab3:
-        show_wal_checkpoint()
+        show_maintenance_db()
 
 def show_export():
     st.subheader("データベースエクスポート")
@@ -113,11 +113,14 @@ def show_import():
                                         f"INSERT INTO {table_name} ({columns_str}) VALUES ({placeholders})",
                                         values
                                     )
-                        
+
+                        # 統計情報の更新
+                        c.execute("ANALYZE;")
+
                         # コミット
                         conn.commit()
                         st.success("データのインポートが完了しました。")
-                        
+
                     except Exception as e:
                         # エラー時はロールバック
                         conn.rollback()
@@ -129,16 +132,20 @@ def show_import():
         except Exception as e:
             st.error(f"ファイルの読み込みに失敗しました: {str(e)}") 
 
-def show_wal_checkpoint():
+def show_maintenance_db():
     st.subheader("データベース整理")
 
-    # WALチェックポイントを実行する関数
-    def run_wal_checkpoint():
+    # データベース整理の実行
+    def run_maintenance_db():
         conn = get_connection()
         c = conn.cursor()
 
         try:
+            # WALチェックポイントを実行する関数
             c.execute("PRAGMA wal_checkpoint(FULL);")
+
+            # 統計情報の更新
+            c.execute("ANALYZE;")
 
         except Exception as e:
             # PRAGMA wal_checkpointはトランザクション外のコマンドのためRollBack不可
@@ -148,5 +155,5 @@ def show_wal_checkpoint():
             conn.close()
 
     if st.button("データベース整理実行"):
-        run_wal_checkpoint()
+        run_maintenance_db()
         st.success("データベース整理を実行しました")

--- a/pages/db_management.py
+++ b/pages/db_management.py
@@ -147,6 +147,9 @@ def show_maintenance_db():
             # 統計情報の更新
             c.execute("ANALYZE;")
 
+            # DBファイルのサイズ最適化
+            c.execute("VACUUM;")
+
         except Exception as e:
             # PRAGMA wal_checkpointはトランザクション外のコマンドのためRollBack不可
             st.error(f"データベース整理に失敗しました: {str(e)}") 

--- a/pages/stock_master.py
+++ b/pages/stock_master.py
@@ -179,6 +179,10 @@ def save_new_stock(stock_code, stock_name):
             """,
             (stock_code, stock_name)
         )
+
+        # 統計情報の更新 (適宜)
+        c.execute("PRAGMA optimize;")
+
         conn.commit()
         st.success(f"銘柄コード {stock_code} を登録/更新しました。")
     except Exception as e:
@@ -193,7 +197,7 @@ def save_bulk_stocks(df):
     success_count = 0
     update_count = 0
     error_count = 0
-    
+ 
     for _, row in df.iterrows():
         try:
             # 既存のレコードをチェック
@@ -214,11 +218,14 @@ def save_bulk_stocks(df):
                 update_count += 1
             else:
                 success_count += 1
-                
+
         except Exception as e:
             error_count += 1
             st.error(f"銘柄コード {row['銘柄コード']} の登録に失敗しました: {str(e)}")
-    
+
+    # 統計情報の更新
+    c.execute("ANALYZE stock_master;")
+
     conn.commit()
     conn.close()
     

--- a/pages/survey.py
+++ b/pages/survey.py
@@ -70,6 +70,9 @@ def save_survey_data(selected_date_str):
                 "INSERT INTO survey (survey_date, stock_code, created_at) VALUES (?, ?, ?)",
                 (selected_date_str, code, now)
             )
-    
+
+    # 統計情報の更新 (適宜)
+    c.execute("PRAGMA optimize;")
+
     conn.commit()
     conn.close() 

--- a/pages/vote.py
+++ b/pages/vote.py
@@ -194,7 +194,10 @@ def save_vote_data(selected_date_str, results):
             # 進捗バーを更新
             progress = (i + 1) / len(selected_codes)
             progress_bar.progress(progress)
-        
+
+        # 統計情報の更新 (適宜)
+        c.execute("PRAGMA optimize;")
+
         conn.commit()
         conn.close()
         


### PR DESCRIPTION
## 目的
パフォーマンス維持・改善

## 概要
 #8 でINDEXを張る対応を入れました。
今回は、INDEXをより利用出来る様にするため統計情報を更新したくPRします。

下記にある通り (SELECT等の) Query実行時にQueryOptimizerで実行計画を立てる段階で、INDEX利用を促進する様にします。

[SQLite ANALYZE](https://www.sqlite.org/lang_analyze.html)
```
1. Overview
The ANALYZE command gathers statistics about tables and indices and stores the collected
 information in internal tables of the database where the query optimizer can access the information and use it to help make better query planning choices.
 If no arguments are given, the main database and all attached databases are analyzed.
 If a schema name is given as the argument, then all tables and indices in that one database are analyzed.
 If the argument is a table name, then only that table and the indices associated with that table are analyzed. If the argument is an index name, then only that one index is analyzed.
```

QueryOptimizerの概略や役割は、下記をご参照ください。
* [Qiita 実行計画？？統計情報？？って人へ](https://qiita.com/NagaokaKenichi/items/5b6eb9887f88046a594d)

SQLiteの統計情報の更新には2種類があるようでした。
|Key|Value|Note|
|---|---|---|
| `ANALYZE` | 統計情報の更新を確実に行う場合。 |[1. Overview](https://www.sqlite.org/lang_analyze.html#overview)<br>→ `The ANALYZE command gathers statistics about tables and indices and stores the collected information ...(略)...` |
| `PRAGMA optimize` | 必要に応じて統計情報の更新を行う場合。|[2.1. Periodically run "PRAGMA optimize"](https://www.sqlite.org/lang_analyze.html#periodically_run_pragma_optimize_)<br>→ `The PRAGMA optimize command will automatically run ANALYZE when needed. Suggested use:...(略)...` |

それぞれの役割を考慮し、
* 一括登録時は、レコードの変更件数が多くなるため `ANALYZE` で統計情報を更新する。
→ 銘柄マスター（一括登録）時、データベース管理（インポート）時
* 個別登録時は、レコードの変更件数が少ないため、 `PRAGMA optimize` を利用し、SQLiteで統計情報の更新有無を適宜判断させる。
→ 銘柄コード登録、銘柄投票時、銘柄マスター（新規登録）時

という風にしています。

ついでに。
「データベース管理」→「データベース整理」の際に、DBファイルのサイズを最小化(=断片化の解消)するために `VACUUM` を入れました。

[SQLite - VACUUM](https://www.sqlite.org/lang_vacuum.html)
```
2. Description
The VACUUM command rebuilds the database file, repacking it into a minimal amount of disk space.
 There are several reasons an application might do this: ...(略)...
```

## 効果
 `ANALYZE` 
* 実行前
→ 初回は内部テーブル `sqlite_stat1` 無し。
```
% sqlite3 survey.db
SQLite version 3.43.2 2023-10-10 13:08:14
Enter ".help" for usage hints.
sqlite> SELECT * FROM sqlite_stat1;
Parse error: no such table: sqlite_stat1
sqlite> 
```
* 実行後
→ ANALYZE実行後は、内部テーブル `sqlite_stat1` にレコード件数が入る様になります。
「データベース管理」→「インポート」実施後の状態
```
sqlite> SELECT * FROM sqlite_stat1;
stock_master|sqlite_autoindex_stock_master_1|4543 1
vote|idx_vote_date_stock_code|11341 454 7
survey|idx_survey_date_stock_code|7756 288 4
sqlite>
```

 `PRAGMA optimize` 
→ SQLiteが個別に統計情報の更新要否を判断するため、現時点で差分が出ませんでした。
