### PR TITLE
投票統計情報の表示機能の推移を追加(#13追従)

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -1,10 +1,24 @@
 import sqlite3
+import os
 from datetime import datetime
 import streamlit as st
 
+def get_db_path():
+    """データベースファイルのパスを取得"""
+    # Azure App Serviceの永続的なストレージパス
+    if os.environ.get('WEBSITE_INSTANCE_ID'):
+        # Azureの場合は/home配下を使用
+        db_dir = '/home/data'
+        os.makedirs(db_dir, exist_ok=True)
+        return os.path.join(db_dir, 'survey.db')
+    else:
+        # ローカル開発環境
+        return 'survey.db'
+
 def get_connection():
     # SQLite の DB ファイル (survey.db) に接続（マルチスレッド対応のため check_same_thread=False）
-    return sqlite3.connect("survey.db", check_same_thread=False)
+    db_path = get_db_path()
+    return sqlite3.connect(db_path, check_same_thread=False)
 
 @st.cache_resource(ttl=24*3600)  # 24時間（1日）でキャッシュを無効化
 def init_db():


### PR DESCRIPTION
# 目的
投票数、投票者数の推移を表示させる対応。

# 概要
2025.6.17の質疑応答会で投票数の合計、投票者数が何人程度いるか把握したいというオーダーがあった。
#13 にて投票日当日の数を出す対応がなされたため「④ 投票結果の推移」画面でも対応します。

# 動作確認
「④ 投票結果の推移」画面
投票数と投票数の数のスケールがだいぶ違うので、見やすくするためグラフを分けました。
 `st.line_chart()` の制約で、グラフの色を違う色に出来なかったので同色です。そこはすいません。（速度優先）
* デフォルト表示
→ 画面上の日本株・米国株の表示期間に合っている。
<img width="772" alt="image" src="https://github.com/user-attachments/assets/13b42c25-392f-4ca3-b9f8-609d5df3fc46" />

* スライダーで期間変更した場合の表示
→ スライダーした期間のみ表示される。
<img width="793" alt="image" src="https://github.com/user-attachments/assets/904962a9-799a-4820-9d98-fb890d15560e" />
