### PR TITLE
Fix: 投票画面のチェック操作ごとのWebSocket通信をform化で抑制（負荷軽減）

### DIFF
--- a/pages/vote.py
+++ b/pages/vote.py
@@ -127,40 +127,46 @@ def show(selected_date):
         3. 選択が完了したら下部の「投票」ボタンを押してください
         """)
         st.markdown("---")
-        
-        st.write("最新の集計結果（投票前のアンケート集計）")
-        
-        # 表形式で表示
-        header_cols = st.columns([0.5, 1, 1, 1])
-        header_cols[0].write("No.")
-        header_cols[1].write("銘柄コード投票")
-        header_cols[2].write("銘柄名")
-        header_cols[3].write("アンケート票数")
-        
-        for index, row in enumerate(sorted_results, 1):
-            stock_code, survey_count, stock_name = row
-            display_name = stock_name or stock_code  # stock_nameがNoneの場合はstock_codeを使用
-            url = f"https://jp.tradingview.com/chart/?symbol={stock_code}"
-            stock_name_link = f'<a href="{url}" target="_blank" rel="noopener noreferrer">{display_name}</a>'
-            
-            cols = st.columns([0.5, 1, 1, 1])
-            cols[0].write(f"{index}")
-            cols[1].checkbox(stock_code, key=f"checkbox_{stock_code}")
-            cols[2].markdown(stock_name_link, unsafe_allow_html=True)
-            cols[3].write(survey_count)
-        
-        st.markdown("---")
+
         # 投票ボタンの状態管理
         if 'vote_submitted' not in st.session_state:
             st.session_state.vote_submitted = False
-        
-        if not st.session_state.vote_submitted:
-            if st.button("投票"):
-                st.session_state.vote_submitted = True  # ボタンがクリックされたことを記録
-                with st.spinner("投票を保存中..."):
-                    save_vote_data(selected_date_str, sorted_results)
-        else:
+        submitted = False
+
+        st.write("最新の集計結果（投票前のアンケート集計）")
+        with st.form("vote_form"):
+            # 表形式で表示
+            header_cols = st.columns([0.5, 1, 1, 1])
+            header_cols[0].write("No.")
+            header_cols[1].write("銘柄コード投票")
+            header_cols[2].write("銘柄名")
+            header_cols[3].write("アンケート票数")
+
+            for index, row in enumerate(sorted_results, 1):
+                stock_code, survey_count, stock_name = row
+                display_name = stock_name or stock_code  # stock_nameがNoneの場合はstock_codeを使用
+                url = f"https://jp.tradingview.com/chart/?symbol={stock_code}"
+                stock_name_link = f'<a href="{url}" target="_blank" rel="noopener noreferrer">{display_name}</a>'
+
+                cols = st.columns([0.5, 1, 1, 1])
+                cols[0].write(f"{index}")
+                cols[1].checkbox(stock_code, key=f"checkbox_{stock_code}")
+                cols[2].markdown(stock_name_link, unsafe_allow_html=True)
+                cols[3].write(survey_count)
+
+            st.markdown("---")
+
+            # フォーム専用の送信ボタン（WebSocket通信軽減）
+            submitted = st.form_submit_button("投票")
+
+        # 投票チェック
+        if submitted and not st.session_state.vote_submitted:
+            st.session_state.vote_submitted = True  # ボタンがクリックされたことを記録
+            with st.spinner("投票を保存中..."):
+                save_vote_data(selected_date_str, sorted_results)
+        elif st.session_state.vote_submitted:
             st.info("投票は完了しています。")
+
     else:
         st.write("対象日のデータはまだありません。")
 


### PR DESCRIPTION
# 目的
銘柄投票時のサーバ負荷軽減

# 概要
2026.2現在、投票人数が140+と増えてきました。
質疑応答会の中でも負荷軽減について言及があったようです。

2026.2.28の投票時に操作していて気づいた事象として、
「銘柄投票」画面の銘柄をチェックOn/OffするタイミングでWebSocket通信していることがわかりました。
（銘柄のチェックをOn/Offする度に画面右上の自転車アイコンが一瞬表示される状態）

1インスタンスで運用しているサーバとしては、無視できない負荷だと思いますので、
 `with st.form("vote_form"):` で囲い、銘柄のチェックOn/Off時に通信しないように修正します。

# 効果
投票時間中の `1,078.22回` の再描画削減効果が見込まれます。

参考値
```
2026.2.28の投票の際には
* 総数 1,079
* 人数 143

でしたので、`1,079 / 143 = 7.54..銘柄/名` 
7.54銘柄 * 143人 = 1,078.22回
という計算です。
```


# 補足
ChatGPT曰く、以下のような挙動の違いがあるそうです。
```
1️⃣ Streamlitの標準動作（フォームなし）
ユーザーがチェックON/OFFするたびに スクリプト全体が上から下まで rerun される
	•	しかもブラウザ → サーバー間は WebSocket通信で状態同期
	•	銘柄が大量にあると、チェック1回で 列ごと全描画 + WebSocket通信 が発生
	•	これが 体感の重さ の原因
例：100銘柄あったら、チェック1回で100行全部再描画 & WebSocket送信


2️⃣ st.form() を使った場合
	•	フォーム内の インタラクションは「送信ボタンが押されるまで rerun されない」
	•	チェックON/OFFをいくらやっても WebSocket通信は発生しない
	•	サーバー側の Python スクリプトも再実行されない
	•	送信ボタン押下時だけ rerun → WebSocket通信 → DB保存
```

# 動作確認
## UI
* 表示された銘柄をチェックOn/Off
→ 右上の自転車アイコンが表示されないことを確認。
一瞬表示されるかされないか程度なのでエビデンス画像としては普通の画像になります。
<img width="881" height="189" alt="image" src="https://github.com/user-attachments/assets/706469b7-4669-46d9-bac2-2658bccf82b9" />
* 投票確認
投票の判定部分を操作しているため、投票成功、既に投票済の2パターンを確認。（正常性確認）
** 通常通り投票出来ることを確認。
<img width="1073" height="907" alt="image" src="https://github.com/user-attachments/assets/4d0d161b-53fe-408f-9c09-280bc122b784" />
** 投票後の再実行で投票完了しているパターンも確認。
<img width="757" height="226" alt="image" src="https://github.com/user-attachments/assets/0a9d14c4-9621-45a1-8985-337de39edd5f" />
