### PR TITLE
Feature: 日本株/米国株チェッカー検知対応

### DIFF
--- a/pages/result.py
+++ b/pages/result.py
@@ -342,10 +342,11 @@ def show(selected_date):
             display_name = stock_name or stock_code  # stock_nameがNoneの場合はstock_codeを使用
             url = f"https://jp.tradingview.com/chart/?symbol={stock_code}"
             stock_name_link = f'<a href="{url}" target="_blank" rel="noopener noreferrer">{display_name}</a>'
-            
+            stock_code_mark = f'<span data-stock-code="{stock_code}">{stock_code}</span>'
+
             cols = st.columns([0.5, 1, 2, 1])
             cols[0].write(f"{index}")
-            cols[1].write(stock_code)
+            cols[1].markdown(stock_code_mark, unsafe_allow_html=True)
             cols[2].markdown(stock_name_link, unsafe_allow_html=True)
             
             percentage = (vote_count / vote_sessions * 100) if vote_sessions > 0 else 0


### PR DESCRIPTION
## 目的
銘柄検索方法の追加

## 概要
「日本株/米国株銘柄チェッカー」を「銘柄投票」に対応したく、検索用のタグを追加させてください。

対応画面は
* 投票画面
* 投票結果画面

の2画面です。

銘柄投票画面はstreamlitの既存タグを利用するため変更箇所なし。
(補足すると専用にタグを追加したところチェックボックスと銘柄コードのテキストの垂直位置がズレるため既存タグを流用する形にしております)

投票結果画面は、検索できるタグが見当たらなかったため銘柄検索用に `data-stock-code` の属性を付与する対応にしています。

実装は
https://github.com/ogalush/jp_us_stock_extension/pull/6/changes#diff-0f94a43463b7813f366856d141269ecb14f708b9a9591f33e26851086d3dd228R15-R37
をご確認ください。

## 関連PR
* https://github.com/ogalush/jp_us_stock_extension/pull/6

## 動作確認
1. 投票画面
銘柄コード側で銘柄コードを検知出来る事を確認しました。
<img width="823" height="335" alt="image" src="https://github.com/user-attachments/assets/27ccc79e-b87b-490d-a37a-3a0fc10d7c62" />
チェックボックスをOn出来る事も確認しました。
<img width="601" height="212" alt="image" src="https://github.com/user-attachments/assets/9687d29f-3262-4ce8-8936-307ef64db520" />

2. 投票結果画面
(1) 銘柄チェッカー方で銘柄コード検知できる事を確認しました。
<img width="530" height="326" alt="image" src="https://github.com/user-attachments/assets/0600799c-7c8b-4b12-9dd5-b28d75ef3f98" />

(2) 実装通り `span data-stock-code="1605"...` が入っている事を確認しました。
ブラウザから閲覧した際に、見た目が崩れない事も確認しました。
```
...(略)...
<div class="st-emotion-cache-6c7yup eoo3rg91">
  <div data-testid="stMarkdownContainer" class="st-emotion-cache-yfw52f eqpbrs00">
    <p><span data-stock-code="1605">1605</span>
    </p>
  </div>
</div>
```
<img width="924" height="166" alt="image" src="https://github.com/user-attachments/assets/846d63a5-e559-491e-a701-507dd229951e" />
