### PR TITLE
Feature: 銘柄投票開始時のChatwork投稿対応 (#19) + レビュー修正

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import streamlit as st
 from utils.db import init_db
 from utils.common import get_date_from_params
 from utils import chatwork
-from pages import top, survey, vote, result, result_graph, stock_master, db_management, stock_evaluation, stock_analysis, investment_simulation, moomoo_pnl, score_ranking, chatwork_post
+from pages import top, survey, vote, vote_chatwork_post, result, result_graph, stock_master, db_management, stock_evaluation, stock_analysis, investment_simulation, moomoo_pnl, score_ranking, chatwork_post
 
 # DB初期化
 init_db()
@@ -41,8 +41,9 @@ st.sidebar.title("ページ選択")
 st.sidebar.markdown(f'<a href="./?page=top&date={date_str}" target="_self">トップページ</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=survey&date={date_str}" target="_self">① 銘柄コード登録</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=vote&date={date_str}" target="_self">② 銘柄投票</a>', unsafe_allow_html=True)
+st.sidebar.markdown(f'<a href="./?page=vote_chatwork_post&date={date_str}" target="_self">②-2 銘柄投票 ChatWork投稿</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=result&date={date_str}" target="_self">③ 投票結果確認</a>', unsafe_allow_html=True)
-st.sidebar.markdown(f'<a href="./?page=chatwork_post&date={date_str}" target="_self">③-2 ChatWork投稿</a>', unsafe_allow_html=True)
+st.sidebar.markdown(f'<a href="./?page=chatwork_post&date={date_str}" target="_self">③-2 投票結果 ChatWork投稿</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=result_graph&date={date_str}" target="_self">④ 投票結果の推移</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=stock_evaluation&date={date_str}" target="_self">⑤ 投票結果株価評価</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=investment_simulation&date={date_str}" target="_self">⑥ 投資シミュレーション</a>', unsafe_allow_html=True)
@@ -64,6 +65,8 @@ elif page == 'survey':
     survey.show(selected_date)
 elif page == 'vote':
     vote.show(selected_date)
+elif page == 'vote_chatwork_post':
+    vote_chatwork_post.show(selected_date)
 elif page == 'result':
     result.show(selected_date)
 elif page == 'chatwork_post':

--- a/pages/chatwork_post.py
+++ b/pages/chatwork_post.py
@@ -170,7 +170,7 @@ def show(selected_date):
     selected_date_str = selected_date.strftime("%Y-%m-%d")
     date_str = selected_date.strftime("%Y%m%d")
     
-    st.title("ChatWork投稿")
+    st.title("投票結果 ChatWork投稿")
     st.write(f"【対象日】{selected_date_str}")
     
     # 投票結果データ取得

--- a/pages/vote_chatwork_post.py
+++ b/pages/vote_chatwork_post.py
@@ -8,31 +8,29 @@ import streamlit as st
 from utils.common import format_vote_data_with_thresh
 from utils.db import get_connection
 from utils import chatwork
-from io import BytesIO
-import platform
-import os
 
 
 def _get_survey_data(selected_date_str):
     """対象日の投票結果データと投票セッション数を取得"""
     conn = get_connection()
-    c = conn.cursor()
+    try:
+        c = conn.cursor()
 
-    # surveyテーブルから対象日の各銘柄のアンケート票数を集計
-    c.execute(
-        """
-        SELECT s.stock_code, COUNT(*) as survey_count, m.stock_name
-        FROM survey s
-        LEFT JOIN stock_master m ON s.stock_code = m.stock_code
-        WHERE s.survey_date = ?
-        GROUP BY s.stock_code
-        """,
-        (selected_date_str,)
-    )
-    results = c.fetchall()
-    conn.close()
-
-    return results
+        # surveyテーブルから対象日の各銘柄のアンケート票数を集計
+        c.execute(
+            """
+            SELECT s.stock_code, COUNT(*) as survey_count, m.stock_name
+            FROM survey s
+            LEFT JOIN stock_master m ON s.stock_code = m.stock_code
+            WHERE s.survey_date = ?
+            GROUP BY s.stock_code
+            """,
+            (selected_date_str,)
+        )
+        results = c.fetchall()
+        return results
+    finally:
+        conn.close()
 
 
 def _generate_files(results, selected_date, selected_date_str):
@@ -41,8 +39,9 @@ def _generate_files(results, selected_date, selected_date_str):
 
     # 1. テキストファイル（票数付）
     sorted_results_with_thresh = format_vote_data_with_thresh(results)
-    filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}_票数順_票数付.txt"
-    files_to_post.append((filename, sorted_results_with_thresh.encode("utf-8"), "text/plain"))
+    if sorted_results_with_thresh:
+        filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}_票数順_票数付.txt"
+        files_to_post.append((filename, sorted_results_with_thresh.encode("utf-8"), "text/plain"))
 
     return files_to_post
 

--- a/pages/vote_chatwork_post.py
+++ b/pages/vote_chatwork_post.py
@@ -1,0 +1,123 @@
+"""
+ChatWork投稿専用ページ
+
+銘柄コード登録のファイルをChatWorkに投稿する機能を提供する。
+voteページからChatWork処理を分離し、パフォーマンスを改善する。
+"""
+import streamlit as st
+from utils.common import format_vote_data_with_thresh
+from utils.db import get_connection
+from utils import chatwork
+from io import BytesIO
+import platform
+import os
+
+
+def _get_survey_data(selected_date_str):
+    """対象日の投票結果データと投票セッション数を取得"""
+    conn = get_connection()
+    c = conn.cursor()
+
+    # surveyテーブルから対象日の各銘柄のアンケート票数を集計
+    c.execute(
+        """
+        SELECT s.stock_code, COUNT(*) as survey_count, m.stock_name
+        FROM survey s
+        LEFT JOIN stock_master m ON s.stock_code = m.stock_code
+        WHERE s.survey_date = ?
+        GROUP BY s.stock_code
+        """,
+        (selected_date_str,)
+    )
+    results = c.fetchall()
+    conn.close()
+
+    return results
+
+
+def _generate_files(results, selected_date, selected_date_str):
+    """投稿用ファイル（テキスト）を生成"""
+    files_to_post = []
+
+    # 1. テキストファイル（票数付）
+    sorted_results_with_thresh = format_vote_data_with_thresh(results)
+    filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}_票数順_票数付.txt"
+    files_to_post.append((filename, sorted_results_with_thresh.encode("utf-8"), "text/plain"))
+
+    return files_to_post
+
+
+def show(selected_date):
+    selected_date_str = selected_date.strftime("%Y-%m-%d")
+    date_str = selected_date.strftime("%Y%m%d")
+
+    st.title("銘柄投票 ChatWork投稿")
+    st.write(f"【対象日】{selected_date_str}")
+
+    # 銘柄コード登録結果を取得
+    results = _get_survey_data(selected_date_str)
+
+    if not results:
+        st.warning("対象日の銘柄コード登録がありません。銘柄コード登録がある日付を選択してください。")
+        st.markdown(
+            f'<a href="./?page=vote&date={date_str}" target="_self">← 銘柄投票ページに戻る</a>',
+            unsafe_allow_html=True
+        )
+        return
+
+    # 投稿ファイルの生成
+    with st.spinner("投稿ファイルを生成中..."):
+        files_to_post = _generate_files(results, selected_date, selected_date_str)
+
+    # ファイルプレビュー
+    st.subheader("投稿予定ファイル")
+    if files_to_post:
+        for fname, data, mime in files_to_post:
+            size_kb = len(data) / 1024
+            st.write(f"📄 **{fname}** ({size_kb:.1f} KB)")
+    else:
+        st.warning("投稿するファイルがありません。")
+        return
+
+    st.markdown("---")
+
+    # ====== ChatWork認証・投稿セクション ======
+    st.subheader("ChatWork認証")
+
+    if not chatwork.is_logged_in():
+        st.info("ChatWorkにログインして投稿してください。")
+        chatwork.show_login_button(return_page="vote_chatwork_post", return_date=date_str)
+    else:
+        try:
+            if not chatwork.is_room_member():
+                st.warning("このルームのメンバーではないため、投稿できません。先にChatWorkでルームに参加してください。")
+                chatwork.show_logout_button()
+            else:
+                # ログインユーザー情報を取得
+                profile = chatwork.get_my_profile()
+                user_name = profile.get("name", "不明") if profile else "不明"
+                
+                col_status, col_logout = st.columns([3, 1])
+                with col_status:
+                    st.success(f"ログインOK（{user_name}）& ルームメンバー確認OK ✅")
+                with col_logout:
+                    chatwork.show_logout_button()
+                
+                # 投稿ボタン
+                if st.button("ChatWorkに投稿", type="primary"):
+                    try:
+                        message = f"銘柄コード登録結果 ({selected_date_str})"
+                        chatwork.post_files_to_room(files_to_post, message)
+                        st.success("ChatWorkに投稿しました！ 🎉")
+                    except Exception as e:
+                        st.error(f"投稿エラー: {e}")
+        except Exception as e:
+            st.error(f"ChatWork API エラー: {e}")
+            st.info("トークンが無効な場合は、ログアウトしてから再度ログインしてください。")
+            chatwork.show_logout_button()
+
+    st.markdown("---")
+    st.markdown(
+        f'<a href="./?page=vote&date={date_str}" target="_self">← 銘柄投票ページに戻る</a>',
+        unsafe_allow_html=True
+    )


### PR DESCRIPTION
## 概要
銘柄投票開始時にアップロードされる「銘柄発掘YYYYMMDD_票数順_票数付.txt」のChatWork投稿機能を追加しました。

既存の「投票結果 ChatWork投稿画面」のロジックを流用し、新ページ `vote_chatwork_post` を作成。

## 主な変更内容

### 新機能追加
- **新ページ追加**: `pages/vote_chatwork_post.py` (銘柄投票 ChatWork投稿)
- **メニュー追加**: サイドバーに「②-2 銘柄投票 ChatWork投稿」リンク追加
- **メニュー名変更**: 既存「ChatWork投稿」→「投票結果 ChatWork投稿」（区別のため）

### コードレビュー修正 (R-1~R-3)
- ✅ **未使用import削除**: `BytesIO`, `platform`, `os` を削除
- ✅ **DB接続修正**: `_get_survey_data` に `try/finally` 追加（接続リーク防止）
- ✅ **戻り値チェック追加**: 空ファイル投稿防止のためガード条件追加

## 変更ファイル
- `app.py` - import、ルーティング、サイドバーメニュー追加
- `pages/chatwork_post.py` - タイトル変更（「投票結果 ChatWork投稿」）
- `pages/vote_chatwork_post.py` - **新規作成** (123行)

## 効果
銘柄コード一覧をダウンロード後、手動でファイルを探してアップロードする手間を削減。