### PR TITLE
Fix: 日付未指定時のJST基準化／ファイル名の誤認防止

### DIFF
--- a/pages/chatwork_post.py
+++ b/pages/chatwork_post.py
@@ -83,7 +83,7 @@ def _generate_files(results, vote_sessions, selected_date, selected_date_str):
     # 1. テキストファイル（票数付）
     sorted_results_with_thresh = format_vote_data_with_thresh(results)
     if sorted_results_with_thresh:
-        filename = f"投票結果{selected_date.strftime('%Y%m%d')}_票数付.txt"
+        filename = f"投票結果_{selected_date.strftime('%Y%m%d')}_票数付.txt"
         files_to_post.append((filename, sorted_results_with_thresh.encode("utf-8"), "text/plain"))
     
     # 2. ワードクラウド画像 & 3. ランキング画像
@@ -110,7 +110,7 @@ def _generate_files(results, vote_sessions, selected_date, selected_date_str):
         buf_wc = BytesIO()
         fig_wc.savefig(buf_wc, format="png", bbox_inches='tight', pad_inches=0.1)
         plt.close(fig_wc)
-        wordcloud_filename = f"銘柄投票{selected_date.strftime('%Y%m%d')}.png"
+        wordcloud_filename = f"投票結果_{selected_date.strftime('%Y%m%d')}.png"
         files_to_post.append((wordcloud_filename, buf_wc.getvalue(), "image/png"))
         
         # ランキング画像
@@ -157,7 +157,7 @@ def _generate_files(results, vote_sessions, selected_date, selected_date_str):
         buf_rank = BytesIO()
         fig_table.savefig(buf_rank, format="png", bbox_inches='tight', pad_inches=0.1)
         plt.close(fig_table)
-        ranking_filename = f"銘柄投票ランキング{selected_date.strftime('%Y%m%d')}.png"
+        ranking_filename = f"投票結果ランキング_{selected_date.strftime('%Y%m%d')}.png"
         files_to_post.append((ranking_filename, buf_rank.getvalue(), "image/png"))
         
     except ImportError:

--- a/pages/result.py
+++ b/pages/result.py
@@ -111,13 +111,13 @@ def show(selected_date):
         # テキストファイルExportボタン
         codes = [row[0] for row in results]
         file_content = "\n".join(codes)
-        filename = f"投票結果{selected_date.strftime('%Y%m%d')}.txt"
+        filename = f"投票結果_{selected_date.strftime('%Y%m%d')}.txt"
         with row1_col1:
             st.download_button("銘柄コードExport", data=file_content, file_name=filename, mime="text/plain")
 
         sorted_results_with_thresh = format_vote_data_with_thresh(results)
         if sorted_results_with_thresh:
-            filename = f"投票結果{selected_date.strftime('%Y%m%d')}_票数付.txt"
+            filename = f"投票結果_{selected_date.strftime('%Y%m%d')}_票数付.txt"
 
             with row1_col2:
                 st.download_button("銘柄コードExport(票数付)", data=sorted_results_with_thresh, file_name=filename, mime="text/plain")
@@ -138,7 +138,7 @@ def show(selected_date):
         csv_str = output.getvalue()
         csv_bytes = csv_str.encode('shift-jis', errors='replace')
         
-        csv_filename = f"投票結果{selected_date.strftime('%Y%m%d')}.csv"
+        csv_filename = f"投票結果_{selected_date.strftime('%Y%m%d')}.csv"
         with row2_col1:
             st.download_button(
                 "投票結果CSV Export",
@@ -148,7 +148,7 @@ def show(selected_date):
             )
         
         # Excelファイルのエクスポート
-        excel_filename = f"投票結果{selected_date.strftime('%Y%m%d')}.xlsx"
+        excel_filename = f"投票結果_{selected_date.strftime('%Y%m%d')}.xlsx"
         
         # DataFrameを作成（URLなし）
         excel_data = [(row[0], row[1], row[2] or row[0]) for row in results]
@@ -225,7 +225,7 @@ def show(selected_date):
             # ワードクラウド画像のダウンロードボタン
             buf = BytesIO()
             fig.savefig(buf, format="png", bbox_inches='tight', pad_inches=0.1)
-            wordcloud_filename = f"銘柄投票{selected_date.strftime('%Y%m%d')}.png"
+            wordcloud_filename = f"投票結果_{selected_date.strftime('%Y%m%d')}.png"
             wordcloud_data = buf.getvalue()
 
             st.download_button(
@@ -308,7 +308,7 @@ def show(selected_date):
             
             ranking_buf = BytesIO()
             ranking_fig.savefig(ranking_buf, format="png", bbox_inches='tight', pad_inches=0.1)
-            ranking_filename = f"銘柄投票ランキング{selected_date.strftime('%Y%m%d')}.png"
+            ranking_filename = f"投票結果ランキング_{selected_date.strftime('%Y%m%d')}.png"
             ranking_data = ranking_buf.getvalue()
 
             

--- a/pages/vote.py
+++ b/pages/vote.py
@@ -45,13 +45,13 @@ def show(selected_date):
         # テキストファイルExportボタン
         codes = [row[0] for row in sorted_results]
         file_content = "\n".join(codes)
-        filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}{sort_suffix}.txt"
+        filename = f"銘柄発掘_{selected_date.strftime('%Y%m%d')}{sort_suffix}.txt"
         with row1_col1:
             st.download_button("銘柄コードExport", data=file_content, file_name=filename, mime="text/plain")
 
         if sorted_results_with_thresh:
             with row1_col2:
-                filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}{sort_suffix}_票数付.txt"
+                filename = f"銘柄発掘_{selected_date.strftime('%Y%m%d')}{sort_suffix}_票数付.txt"
                 st.download_button("銘柄コードExport(票数付)", data=sorted_results_with_thresh, file_name=filename, mime="text/plain")
         
         row2_col1, row2_col2 = st.columns(2)
@@ -70,7 +70,7 @@ def show(selected_date):
         csv_str = output.getvalue()
         csv_bytes = csv_str.encode('shift-jis', errors='replace')
         
-        csv_filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}{sort_suffix}.csv"
+        csv_filename = f"銘柄発掘_{selected_date.strftime('%Y%m%d')}{sort_suffix}.csv"
         with row2_col1:
             st.download_button(
                 "集計結果CSV Export",
@@ -80,7 +80,7 @@ def show(selected_date):
             )
         
         # Excelファイルのエクスポート
-        excel_filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}{sort_suffix}.xlsx"
+        excel_filename = f"銘柄発掘_{selected_date.strftime('%Y%m%d')}{sort_suffix}.xlsx"
         
         # DataFrameを作成（URLなし）
         excel_data = [(row[0], row[1], row[2] or row[0]) for row in sorted_results]

--- a/pages/vote_chatwork_post.py
+++ b/pages/vote_chatwork_post.py
@@ -40,7 +40,7 @@ def _generate_files(results, selected_date, selected_date_str):
     # 1. テキストファイル（票数付）
     sorted_results_with_thresh = format_vote_data_with_thresh(results)
     if sorted_results_with_thresh:
-        filename = f"銘柄発掘{selected_date.strftime('%Y%m%d')}_票数順_票数付.txt"
+        filename = f"銘柄発掘_{selected_date.strftime('%Y%m%d')}_票数順_票数付.txt"
         files_to_post.append((filename, sorted_results_with_thresh.encode("utf-8"), "text/plain"))
 
     return files_to_post

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,4 +1,5 @@
-from datetime import datetime, date
+from datetime import datetime
+from zoneinfo import ZoneInfo
 import yfinance as yf
 from utils.db import get_connection
 
@@ -29,8 +30,8 @@ def get_date_from_params(query_params):
         try:
             return datetime.strptime(date_param, "%Y%m%d").date()
         except ValueError:
-            return date.today()
-    return date.today()
+            return datetime.now(ZoneInfo("Asia/Tokyo")).date()
+    return datetime.now(ZoneInfo("Asia/Tokyo")).date()
 
 
 THRESHOLDS=[100, 50, 30, 20, 10, 5]

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,6 +1,7 @@
 import sqlite3
 import os
 from datetime import datetime
+from zoneinfo import ZoneInfo
 import streamlit as st
 
 def get_db_path():
@@ -102,7 +103,7 @@ def init_db():
     conn.close()
 
     # キャッシュの有効期限を確認するために実行時刻をログ出力
-    st.write(f"DBキャッシュ: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    st.write(f"DBキャッシュ: {datetime.now(ZoneInfo('Asia/Tokyo')).strftime('%Y-%m-%d %H:%M:%S JST')}")
 
 def init_price_cache_table():
     """株価キャッシュテーブルを初期化"""


### PR DESCRIPTION
## 目的
- 銘柄発掘／投票時の日付誤りリスクの軽減
- 投票結果ファイル名の誤認防止

## 概要

### 1. タイムゾーン修正

**事象**  
2026/4/28 の銘柄発掘案内にて、前回投票日（4/25）のURLを案内し、当日の発掘が遅延。  
https://www.chatwork.com/#!rid93885653-2100926462646554624

**問題**  
`date` パラメータ未指定で回避可能と考えたが、Azure App Service が UTC のため、JST 0:00〜9:00 の間に日付ズレが発生し、ユーザーごとに投票日が異なる。
実際の投票は 20:15-20:45 のため影響は出ていないが、潜在的な不整合リスクがある。

関連箇所：
- https://github.com/kita-develop/discover-stocks/blob/main/app.py#L31  
- https://github.com/kita-develop/discover-stocks/blob/main/utils/common.py#L26-L33  
  - `get_date_from_params()`
```
def get_date_from_params(query_params):
    if 'date' in query_params:
        date_param = query_params['date'].strip()
        try:
            return datetime.strptime(date_param, "%Y%m%d").date()
        except ValueError:
            return date.today()
    return date.today()
```

**対応**  
- 投票日をタイムゾーン非依存にするため、JST を明示的に使用  
- 画面上部の「DBキャッシュ」期限表示も併せて修正（誤認防止）

**影響範囲**  
- 既存データ・分析ロジックへの影響なし（DB内の日時仕様は変更しない）

---

### 2. ファイル名修正

**事象**  
質疑応答会にて、「銘柄発掘」と「投票結果」のファイル名が混同されるケースが発生。

**問題**
Mac から TradingView へアップロードする際に、意図しないファイルを選択するリスクがある。

**対応**  
視認性向上および誤認防止のため、以下の通り修正。

- `銘柄発掘20260428..` → `銘柄発掘_20260428`
  （種類と日付の区別を明確化するため）
- 投票結果ファイル名を `投票結果_..` に統一  
  （画面名に「銘柄投票」が含まれるため混同回避）

---

## 動作確認
### 1. タイムゾーン修正
動作確認環境のMacのタイムゾーンを変更して確認。
日本時間の 0:00-9:00のタイミングで日にちが合っていることを確認しました。
<img width="1141" height="320" alt="image" src="https://github.com/user-attachments/assets/d0b1a389-689c-457a-8d53-c9386bb62c53" />

### 2. ファイル名修正
「銘柄投票_」、「投票結果_」など区切り文字が入っていることを確認しました。
* 銘柄投票画面
<img width="606" height="642" alt="image" src="https://github.com/user-attachments/assets/a85ebb67-96d2-4569-80b3-aacf053ed004" />

* 銘柄投票 Chatwork投稿
<img width="497" height="288" alt="image" src="https://github.com/user-attachments/assets/2229a3f7-5de6-49fd-9a8e-e9c4f3975806" />

* 投票結果確認
<img width="619" height="650" alt="image" src="https://github.com/user-attachments/assets/da7fae7a-39c0-4c5f-a2ea-664bb81e7524" />

* 投票結果 ChatWork投稿
<img width="502" height="491" alt="image" src="https://github.com/user-attachments/assets/49291632-1946-4ca4-928d-e732ed21d090" />
