### PR TITLE
Feature: 銘柄コード「0000」を該当なしとする対応

### DIFF
--- a/pages/result.py
+++ b/pages/result.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from utils.common import format_vote_data_with_thresh
+from utils.common import DUMMY_STOCK_CODE, format_vote_data_with_thresh
 from utils.db import get_connection
 
 import csv
@@ -347,7 +347,10 @@ def show(selected_date):
             cols = st.columns([0.5, 1, 2, 1])
             cols[0].write(f"{index}")
             cols[1].markdown(stock_code_mark, unsafe_allow_html=True)
-            cols[2].markdown(stock_name_link, unsafe_allow_html=True)
+            if stock_code != DUMMY_STOCK_CODE:
+                cols[2].markdown(stock_name_link, unsafe_allow_html=True)
+            else:
+                cols[2].text(f"{display_name}")
             
             percentage = (vote_count / vote_sessions * 100) if vote_sessions > 0 else 0
             cols[3].write(f"{vote_count} ({percentage:.1f}%)")

--- a/pages/survey.py
+++ b/pages/survey.py
@@ -2,7 +2,7 @@ import streamlit as st
 import re
 from datetime import datetime
 from utils.db import get_connection
-from utils.common import MAX_SETS, get_stock_name
+from utils.common import MAX_SETS, DUMMY_STOCK_CODE, get_stock_name
 
 def show(selected_date):
     selected_date_str = selected_date.strftime("%Y-%m-%d")
@@ -11,12 +11,15 @@ def show(selected_date):
     st.write(f"【対象日】{selected_date_str}")
     
     # 入力方法の説明を追加
-    st.info("""
+    st.info(f"""
     【銘柄コード入力方法】
     1. 銘柄コードを入力（半角英数字・大文字とピリオドのみ）
     2. 「確定」ボタンをクリックして入力内容を確認
     3. 銘柄名のリンクをクリックすると、TradingViewでチャートを確認できます
     4. 全ての入力が完了したら下部の「送信」ボタンを押してください
+
+    【該当なしの場合】  
+    銘柄コードへ「{DUMMY_STOCK_CODE}」をご入力ください
     """)
     st.markdown("---")
     
@@ -36,7 +39,7 @@ def show(selected_date):
                     st.session_state[f"stock_name_{i}"] = stock_name
                     st.success(f"銘柄コード {code_input} を確定しました。")
                     # 銘柄名が銘柄コードと同じ場合は警告を表示
-                    if stock_name == code_input:
+                    if stock_name == code_input and code_input != DUMMY_STOCK_CODE:
                         st.warning("銘柄名が取得できませんでした。銘柄コードが正しいか確認してください。")
                 else:
                     st.error("入力が不正です。半角英数字・大文字とピリオドのみを使用してください。")
@@ -45,11 +48,14 @@ def show(selected_date):
             if f"confirmed_{i}" in st.session_state:
                 confirmed_code = st.session_state[f"confirmed_{i}"]
                 stock_name = st.session_state.get(f"stock_name_{i}", confirmed_code)
-                url = f"https://jp.tradingview.com/chart/?symbol={confirmed_code}"
-                st.markdown(
-                    f'<a href="{url}" target="_blank" rel="noopener noreferrer">{stock_name}のチャートを表示する</a>',
-                    unsafe_allow_html=True
-                )
+                if confirmed_code != DUMMY_STOCK_CODE:
+                    url = f"https://jp.tradingview.com/chart/?symbol={confirmed_code}"
+                    st.markdown(
+                        f'<a href="{url}" target="_blank" rel="noopener noreferrer">{stock_name}のチャートを表示する</a>',
+                        unsafe_allow_html=True
+                    )
+                else:
+                    st.text(f"{stock_name}")
             else:
                 st.write("")
     

--- a/pages/vote.py
+++ b/pages/vote.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from datetime import datetime
 from utils.db import get_connection
-from utils.common import MAX_VOTE_SELECTION, format_vote_data_with_thresh
+from utils.common import MAX_VOTE_SELECTION, DUMMY_STOCK_CODE, format_vote_data_with_thresh
 import csv
 from io import StringIO
 import pandas as pd
@@ -151,7 +151,10 @@ def show(selected_date):
                 cols = st.columns([0.5, 1, 1, 1])
                 cols[0].write(f"{index}")
                 cols[1].checkbox(stock_code, key=f"checkbox_{stock_code}")
-                cols[2].markdown(stock_name_link, unsafe_allow_html=True)
+                if stock_code != DUMMY_STOCK_CODE:
+                    cols[2].markdown(stock_name_link, unsafe_allow_html=True)
+                else:
+                    cols[2].text(f"{display_name}")
                 cols[3].write(survey_count)
 
             st.markdown("---")

--- a/utils/common.py
+++ b/utils/common.py
@@ -3,6 +3,7 @@ from zoneinfo import ZoneInfo
 import yfinance as yf
 from utils.db import get_connection
 
+DUMMY_STOCK_CODE= "0000" # 銘柄発掘、投票時の「該当なし」のダミーコード
 MAX_SETS = 7            # 銘柄発掘アンケートの入力セット数
 MAX_VOTE_SELECTION = 10 # 集計ページでのチェックボックスの最大選択数
 STOCKS_PER_PAGE = 100   # 銘柄マスタ一覧の1ページあたりの表示件数


### PR DESCRIPTION
## 概要
2026.7.21 質疑応答会にて、銘柄投票のカスタマイズとして「該当なし」の銘柄コードを選択肢へ用意する旨の依頼がありました。

過去に1度、投票の中で `0000` を該当なしで投票したことがあったことを思い出しました。
```
% jq -r '.tables.survey[] | select(.stock_code == "0000")' db_backup_20260721_151428.json
{
  "id": 49419,
  "survey_date": "2026-03-14",
  "stock_code": "0000",
  "created_at": "2026-03-14 11:17:52"
}
```
このコードを恒久的に「該当なし」にするためPRします。

## 補足
[東証上場銘柄一覧（2026年6月末）](https://www.jpx.co.jp/markets/statistics-equities/misc/01.html)のExcelファイルを確認し、問題ないことを確認しました。
日本株の銘柄コードは `1301` 以降のため今回の番号での衝突は今のところ無いです。


## 動作確認
* 前提
「銘柄マスター管理」→「新規登録」から、「0000」が「該当なし」として登録済みであること。

* 銘柄コード登録
→ 「該当なし」の場合の案内、および、銘柄コード入力時に正常終了すること、（ダミーコードのため）URLが表示されないことを確認。
<img width="696" height="709" alt="image" src="https://github.com/user-attachments/assets/f1e69f6d-4d08-44f1-a388-d1af5d6592a9" />

* 銘柄投票
→ 「該当なし」が候補として表示されること。また投票出来ることを確認。
<img width="600" height="267" alt="image" src="https://github.com/user-attachments/assets/15174edb-5122-464e-9d8d-7dbd2c239959" />

* 投票結果確認
→ 投票結果に「該当なし」が表示されることを確認。
<img width="630" height="126" alt="image" src="https://github.com/user-attachments/assets/4dace7fa-29b9-48f0-ad0d-5b8808108dfa" />

## その他
なし