### PR TITLE
Feature: ジャーナリング アンケート画面の追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import streamlit as st
 from utils.db import init_db
 from utils.common import get_date_from_params
 from utils import chatwork
-from pages import top, survey, vote, vote_chatwork_post, result, result_graph, stock_master, db_management, stock_evaluation, stock_analysis, investment_simulation, moomoo_pnl, score_ranking, chatwork_post
+from pages import top, survey, vote, survey_chatwork_post, result, result_graph, stock_master, db_management, stock_evaluation, stock_analysis, investment_simulation, moomoo_pnl, score_ranking, chatwork_post, journal_vote_candidate, journal_vote, journal_vote_result, journal_vote_history, journal_vote_feedback
 
 # DB初期化
 init_db()
@@ -39,14 +39,23 @@ date_str = selected_date.strftime("%Y%m%d")
 # サイドバーにページリンクを追加
 st.sidebar.title("ページ選択")
 st.sidebar.markdown(f'<a href="./?page=top&date={date_str}" target="_self">トップページ</a>', unsafe_allow_html=True)
+st.sidebar.markdown("---")
 st.sidebar.markdown(f'<a href="./?page=survey&date={date_str}" target="_self">① 銘柄コード登録</a>', unsafe_allow_html=True)
+st.sidebar.markdown(f'<a href="./?page=survey_chatwork_post&date={date_str}" target="_self">①-2 銘柄コード登録結果 ChatWork投稿</a>', unsafe_allow_html=True)
+st.sidebar.markdown("---")
 st.sidebar.markdown(f'<a href="./?page=vote&date={date_str}" target="_self">② 銘柄投票</a>', unsafe_allow_html=True)
-st.sidebar.markdown(f'<a href="./?page=vote_chatwork_post&date={date_str}" target="_self">②-2 銘柄投票 ChatWork投稿</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=result&date={date_str}" target="_self">③ 投票結果確認</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=chatwork_post&date={date_str}" target="_self">③-2 投票結果 ChatWork投稿</a>', unsafe_allow_html=True)
+st.sidebar.markdown("---")
 st.sidebar.markdown(f'<a href="./?page=result_graph&date={date_str}" target="_self">④ 投票結果の推移</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=stock_evaluation&date={date_str}" target="_self">⑤ 投票結果株価評価</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=investment_simulation&date={date_str}" target="_self">⑥ 投資シミュレーション</a>', unsafe_allow_html=True)
+st.sidebar.markdown("---")
+st.sidebar.markdown(f'<a href="./?page=journal_vote_candidate&date={date_str}" target="_self">⑦ ジャーナリング 銘柄登録</a>', unsafe_allow_html=True)
+st.sidebar.markdown(f'<a href="./?page=journal_vote&date={date_str}" target="_self">⑦-2 ジャーナリング アンケート</a>', unsafe_allow_html=True)
+st.sidebar.markdown(f'<a href="./?page=journal_vote_result&date={date_str}" target="_self">⑦-3 ジャーナリング アンケート結果</a>', unsafe_allow_html=True)
+st.sidebar.markdown(f'<a href="./?page=journal_vote_history&date={date_str}" target="_self">⑦-3 ジャーナリング 回答参照</a>', unsafe_allow_html=True)
+st.sidebar.markdown(f'<a href="./?page=journal_vote_feedback&date={date_str}" target="_self">⑦-4 ジャーナリング Mr.Kフィードバック参照</a>', unsafe_allow_html=True)
 st.sidebar.markdown("---")
 st.sidebar.markdown(f'<a href="./?page=stock_analysis&date={date_str}" target="_self">特定銘柄分析</a>', unsafe_allow_html=True)
 st.sidebar.markdown(f'<a href="./?page=score_ranking&date={date_str}" target="_self">安定上昇銘柄ランキング </a>', unsafe_allow_html=True)
@@ -65,8 +74,8 @@ elif page == 'survey':
     survey.show(selected_date)
 elif page == 'vote':
     vote.show(selected_date)
-elif page == 'vote_chatwork_post':
-    vote_chatwork_post.show(selected_date)
+elif page == 'survey_chatwork_post':
+    survey_chatwork_post.show(selected_date)
 elif page == 'result':
     result.show(selected_date)
 elif page == 'chatwork_post':
@@ -77,6 +86,16 @@ elif page == 'stock_evaluation':
     stock_evaluation.show(selected_date)
 elif page == 'investment_simulation':
     investment_simulation.show(selected_date)
+elif page == 'journal_vote_candidate':
+    journal_vote_candidate.show(selected_date)
+elif page == 'journal_vote':
+    journal_vote.show(selected_date)
+elif page == 'journal_vote_result':
+    journal_vote_result.show(selected_date)
+elif page == 'journal_vote_history':
+    journal_vote_history.show(selected_date)
+elif page == 'journal_vote_feedback':
+    journal_vote_feedback.show(selected_date)
 elif page == 'stock_analysis':
     stock_analysis.show(selected_date)
 elif page == 'score_ranking':

--- a/pages/db_management.py
+++ b/pages/db_management.py
@@ -30,7 +30,11 @@ def show_export():
     tables = {
         'stock_master': pd.read_sql_query("SELECT * FROM stock_master", conn),
         'survey': pd.read_sql_query("SELECT * FROM survey", conn),
-        'vote': pd.read_sql_query("SELECT * FROM vote", conn)
+        'vote': pd.read_sql_query("SELECT * FROM vote", conn),
+        'journal_vote_candidate': pd.read_sql_query("SELECT * FROM journal_vote_candidate", conn),
+        'journal_vote_base': pd.read_sql_query("SELECT * FROM journal_vote_base", conn),
+        'journal_vote': pd.read_sql_query("SELECT * FROM journal_vote", conn),
+        'journal_vote_feedback': pd.read_sql_query("SELECT * FROM journal_vote_feedback", conn)
     }
     
     conn.close()

--- a/pages/journal_vote.py
+++ b/pages/journal_vote.py
@@ -1,0 +1,352 @@
+import base64
+import pandas as pd
+import streamlit as st
+
+from datetime import datetime
+from utils.db import get_connection
+from utils.common import encrypt_string, get_journal_vote_uuid, QUESTIONNAIRE_VERSION, JOURNAL_SCORE_OPTIONS, WAVE_POSITION_OPTIONS, BASELINE_DIRECTION_OPTIONS, VOLATILITY_SCORE_OPTIONS, EXCEPTION_OPTIONS, LEADER_EXISTS_OPTIONS, MARKET_STATE_SCORE_OPTIONS, CONFIDENCE_SCORE_OPTIONS, FEELING_SCORE_OPTIONS, POSITION_RATIO_MIN, POSITION_RATIO_MAX
+
+def show(selected_date):
+    selected_date_str = selected_date.strftime("%Y-%m-%d")
+
+    st.title("ジャーナリング アンケート")
+    st.write(f"【対象日】{selected_date_str}")
+
+    results = _get_candidates(selected_date_str)
+    if results.empty:
+        st.write("銘柄が登録されていません。")
+        return
+
+    if not "JOURNAL_ENCRYPTION_KEY" in st.secrets:
+        st.error("暗号化キーが設定されていません。")
+        return False
+    JOURNAL_ENCRYPTION_KEY = base64.b64decode(st.secrets["JOURNAL_ENCRYPTION_KEY"])
+
+    st.info("銘柄毎のアンケート、下部の共通アンケートを入力後、投票ボタンを押してください。")
+    if 'journal_submitted' not in st.session_state:
+        st.session_state.journal_submitted = False
+    submitted = False
+
+    uuid = get_journal_vote_uuid()
+    _initialize_widget_state(results)
+
+    with st.form("journal_vote_form"):
+        st.subheader("ジャーナリング銘柄の投票")
+        st.text("チャートだけを見て答えてください。")
+        for _, row in results.iterrows():
+            stock_code = row["stock_code"]
+            stock_name = row["stock_name"]
+
+            with st.expander(f"{stock_code} - {stock_name}", expanded=True):
+                url = f"https://jp.tradingview.com/chart/?symbol={stock_code}"
+                st.markdown(
+                    f'<a href="{url}" target="_blank" rel="noopener noreferrer">チャートを表示する</a>',
+                    unsafe_allow_html=True
+                )
+                st.radio(
+                    f"直近10本の規律可能性は？　{next(iter(JOURNAL_SCORE_OPTIONS))} 完全にランダム  -  {next(reversed(JOURNAL_SCORE_OPTIONS))} 完全に規律正しい",
+                    list(JOURNAL_SCORE_OPTIONS.keys()),
+                    horizontal=True,
+                    key=_score_key(stock_code)
+                )
+                st.radio(
+                    "大きな波の中でどの位置にいると思うか",
+                    list(WAVE_POSITION_OPTIONS.keys()),
+                    format_func=lambda key: WAVE_POSITION_OPTIONS[key],
+                    horizontal=True,
+                    key=_wave_position_key(stock_code),
+                )
+                st.radio(
+                    "ベースラインの方向性について",
+                    list(BASELINE_DIRECTION_OPTIONS.keys()),
+                    format_func=lambda key: BASELINE_DIRECTION_OPTIONS[key],
+                    horizontal=True,
+                    key=_baseline_direction_key(stock_code),
+                )
+                st.radio(
+                    "ボラティリティについて",
+                    list(VOLATILITY_SCORE_OPTIONS.keys()),
+                    format_func=lambda key: VOLATILITY_SCORE_OPTIONS[key],
+                    horizontal=True,
+                    key=_volatility_key(stock_code)
+                )
+                st.radio(
+                    "例外的な判断が必要／不要",
+                    list(EXCEPTION_OPTIONS.keys()),
+                    format_func=lambda key: EXCEPTION_OPTIONS[key],
+                    horizontal=True,
+                    key=_exception_needed_key(stock_code),
+                )
+                st.text_input(
+                    "「必要」と答えた場合のみ -- 理由",
+                    key=_exception_reason_key(stock_code),
+                    placeholder="理由を一行で入力してください",
+                )
+
+            st.markdown("---")
+
+        st.subheader("自分の状態")
+        st.text("チャートの話ではなく、あなた自身の話です。良い悪いはありません。")
+        st.radio(
+            "今の相場は",
+            list(MARKET_STATE_SCORE_OPTIONS.keys()),
+            format_func=lambda key: MARKET_STATE_SCORE_OPTIONS[key],
+            horizontal=True,
+            key="journal_market_state"
+        )
+        st.radio(
+            "自分の状態は",
+            list(CONFIDENCE_SCORE_OPTIONS.keys()),
+            format_func=lambda key: CONFIDENCE_SCORE_OPTIONS[key],
+            horizontal=True,
+            key="journal_confidence"
+        )
+        st.radio(
+            "気持ちは",
+            list(FEELING_SCORE_OPTIONS.keys()),
+            format_func=lambda key: FEELING_SCORE_OPTIONS[key],
+            horizontal=True,
+            key="journal_feeling"
+        )
+        st.selectbox(
+            "今のポジション量は（資金に対する割合）",
+            options=list(range(POSITION_RATIO_MIN, POSITION_RATIO_MAX + 1, 10)),
+            key="journal_position_ratio",
+        )
+        st.radio(
+            "先導株（または先導指数）はあると思いますか？",
+            list(LEADER_EXISTS_OPTIONS.keys()),
+            format_func=lambda key: LEADER_EXISTS_OPTIONS[key],
+            horizontal=True,
+            key="journal_leader_exists",
+        )
+        st.text_input(
+            "「ある」と答えた方のみ──それは何だと思いますか？（銘柄名・コード）",
+            key="journal_leader_name_or_code"
+        )
+        st.markdown("---")
+        st.text_input(
+            "Mr.Kへの突っ込み（任意）",
+            key="journal_teacher_feedback"
+        )
+        submitted = st.form_submit_button("投票")
+
+    if submitted and not st.session_state.journal_submitted:
+        validation_message = _validate_inputs(results)
+        if validation_message:
+            st.error(validation_message)
+            return
+
+        with st.spinner("投票を保存中..."):
+            ok, msg = _save_submission(
+                selected_date_str=selected_date_str,
+                candidates=results.to_dict(orient="records"),
+                uuid=uuid,
+                JOURNAL_ENCRYPTION_KEY=JOURNAL_ENCRYPTION_KEY
+            )
+
+        if ok:
+            st.session_state.journal_submitted = True
+            st.balloons()
+            st.success(msg)
+        else:
+            st.error(msg)
+
+    elif st.session_state.journal_submitted:
+        st.info("投票は完了しています。")
+
+
+def _get_candidates(selected_date_str):
+    conn = get_connection()
+    try:
+        df = pd.read_sql_query(
+            """
+            SELECT
+                c.stock_code,
+                COALESCE(m.stock_name, c.stock_code) AS stock_name
+            FROM journal_vote_candidate c
+            LEFT JOIN stock_master m ON c.stock_code = m.stock_code
+            WHERE c.vote_date = ?
+            ORDER BY c.id
+            """,
+            conn,
+            params=(selected_date_str,),
+        )
+        return df
+    finally:
+        conn.close()
+
+
+def _initialize_widget_state(results):
+    for _, row in results.iterrows():
+        code = row["stock_code"]
+        if _score_key(code) not in st.session_state:
+            st.session_state[_score_key(code)] = 1
+        if _wave_position_key(code) not in st.session_state:
+            st.session_state[_wave_position_key(code)] = "unknown"
+        if _baseline_direction_key(code) not in st.session_state:
+            st.session_state[_baseline_direction_key(code)] = "unknown"
+        if _volatility_key(code) not in st.session_state:
+            st.session_state[_volatility_key(code)] = 1
+        if _exception_needed_key(code) not in st.session_state:
+            st.session_state[_exception_needed_key(code)] = 0
+        if _exception_reason_key(code) not in st.session_state:
+            st.session_state[_exception_reason_key(code)] = None
+
+    if "journal_market_state" not in st.session_state:
+        st.session_state.journal_market_state = 1
+    if "journal_confidence" not in st.session_state:
+        st.session_state.journal_confidence = 1
+    if "journal_feeling" not in st.session_state:
+        st.session_state.journal_feeling = 1
+    if "journal_position_ratio" not in st.session_state:
+        st.session_state.journal_position_ratio = 0
+    if "journal_leader_exists" not in st.session_state:
+        st.session_state.journal_leader_exists = 0
+    if "journal_leader_name_or_code" not in st.session_state:
+        st.session_state.journal_leader_name_or_code = None
+    if "journal_teacher_feedback" not in st.session_state:
+        st.session_state.journal_teacher_feedback = None
+
+
+def _validate_inputs(results):
+    for _, row in results.iterrows():
+        code = row["stock_code"]
+        if st.session_state.get(_exception_needed_key(code)) == 1 and not st.session_state.get(_exception_reason_key(code)):
+            return f"{code} は「必要」を選んだため、その理由を一行で入力してください。"
+
+    if st.session_state.journal_leader_exists == 1 and not st.session_state.get("journal_leader_name_or_code"):
+        return "「ある」を選んだ場合は、先導株または先導指数を入力してください。"
+
+    return None
+
+
+def _save_submission(selected_date_str, candidates, uuid, JOURNAL_ENCRYPTION_KEY):
+    conn = get_connection()
+    try:
+        c = conn.cursor()
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        # トランザクション開始 (複数トランザクションのため)
+        c.execute("BEGIN TRANSACTION")
+
+        ## 共通アンケートを保存
+        journal_cursor = c.execute(
+            """
+            INSERT INTO journal_vote_base (
+                vote_date,
+                uuid,
+                questionnaire_version,
+                market_state,
+                confidence,
+                feeling,
+                position_ratio,
+                leader_exists,
+                leader_name_or_code,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                selected_date_str,
+                uuid,
+                QUESTIONNAIRE_VERSION,
+                st.session_state.journal_market_state,
+                st.session_state.journal_confidence,
+                st.session_state.journal_feeling,
+                st.session_state.journal_position_ratio,
+                st.session_state.journal_leader_exists,
+                st.session_state.journal_leader_name_or_code.strip() if st.session_state.journal_leader_exists else None,
+                now
+            ),
+        )
+        journal_id = journal_cursor.lastrowid
+
+        ## 銘柄毎のアンケートを保存
+        for candidate in candidates:
+            code = candidate["stock_code"]
+            c.execute(
+                """
+                INSERT INTO journal_vote (
+                    vote_date,
+                    vote_journal_id,
+                    stock_code,
+                    score,
+                    wave_position,
+                    baseline_direction,
+                    volatility,
+                    exception_needed,
+                    exception_reason,
+                    created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    selected_date_str,
+                    journal_id,
+                    code,
+                    st.session_state.get(_score_key(code)),
+                    st.session_state.get(_wave_position_key(code)),
+                    st.session_state.get(_baseline_direction_key(code)),
+                    st.session_state.get(_volatility_key(code)),
+                    st.session_state.get(_exception_needed_key(code)),
+                    st.session_state.get(_exception_reason_key(code)).strip() if st.session_state.get(_exception_needed_key(code)) else None,
+                    now
+                ),
+            )
+
+        ## 講師へのフィードバックを保存
+        if st.session_state.journal_teacher_feedback:
+            ## フィードバック文字列暗号化
+            enc_teacher_feedback = encrypt_string(st.session_state.journal_teacher_feedback.strip(), JOURNAL_ENCRYPTION_KEY)
+            c.execute(
+                """
+                INSERT INTO journal_vote_feedback (
+                    vote_date,
+                    vote_journal_id,
+                    teacher_feedback,
+                    created_at
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (
+                    selected_date_str,
+                    journal_id,
+                    enc_teacher_feedback,
+                    now
+                ),
+            )
+
+        # 統計情報の更新 (適宜)
+        c.execute("PRAGMA optimize;")
+
+        conn.commit()
+        return True, "投票が保存されました。"
+
+    except Exception as e:
+        conn.rollback()
+        return False, f"投票の保存中にエラーが発生しました: {str(e)}"
+
+    finally:
+        conn.close()
+
+
+def _score_key(stock_code):
+    return f"journal_score_{stock_code}"
+
+
+def _wave_position_key(stock_code):
+    return f"journal_wave_position_{stock_code}"
+
+
+def _baseline_direction_key(stock_code):
+    return f"journal_baseline_direction_{stock_code}"
+
+
+def _volatility_key(stock_code):
+    return f"journal_volatility_{stock_code}"
+
+
+def _exception_needed_key(stock_code):
+    return f"journal_exception_needed_{stock_code}"
+
+
+def _exception_reason_key(stock_code):
+    return f"journal_exception_reason_{stock_code}"

--- a/pages/journal_vote_candidate.py
+++ b/pages/journal_vote_candidate.py
@@ -1,0 +1,154 @@
+import re
+import pandas as pd
+import streamlit as st
+
+from utils.db import get_connection, get_vote_results_top_n
+from utils.common import JOURNAL_CANDIDATE_COUNT, get_stock_name
+
+def show(selected_date):
+    selected_date_str = selected_date.strftime("%Y-%m-%d")
+
+    st.title("ジャーナリング 銘柄登録")
+    st.write(f"【対象日】{selected_date_str}")
+
+    results = get_vote_results_top_n(selected_date_str, top_n=JOURNAL_CANDIDATE_COUNT)
+    if results:
+        st.info(f"""投票に使う銘柄を{JOURNAL_CANDIDATE_COUNT}件登録します。  
+        「銘柄コードを登録」から登録してください。初期値は上位{JOURNAL_CANDIDATE_COUNT}銘柄です。""")
+        st.subheader("投票候補")
+
+        existing_df = _get_existing_candidates(selected_date_str)
+        if existing_df.empty:
+            st.text("未登録")
+            ## 初回は投票結果の上位N件をsession_stateにセットする
+            for i, row in enumerate(results):
+                key = f"journal_candidate_code_{i + 1}"
+                if key not in st.session_state:
+                    st.session_state[key] = row[0]
+        else:
+            st.dataframe(existing_df[["stock_code", "stock_name", "created_at"]], hide_index=True, use_container_width=True)
+            for i, row in enumerate(existing_df.itertuples(index=False), start=1):
+                key = f"journal_candidate_code_{i}"
+                if key not in st.session_state:
+                    st.session_state[key] = row.stock_code
+
+        st.markdown("---")
+
+        message = st.empty()
+        with st.form("journal_candidate_form"):
+            for i in range(JOURNAL_CANDIDATE_COUNT):
+                code_key = f"journal_candidate_code_{i + 1}"
+                code = st.text_input(f"銘柄コード {i + 1}", key=code_key)
+                if code.strip():
+                    stock_name = get_stock_name(code.strip())
+                    st.caption(f"銘柄名: {stock_name}")
+
+            col1, col2 = st.columns(2)
+            with col1:
+                submitted = st.form_submit_button("銘柄コードを登録")
+            with col2:
+                reset = st.form_submit_button("初期値に戻す")
+        
+        ## フォーム送信時の処理
+        if submitted:
+            codes = [st.session_state[f"journal_candidate_code_{i + 1}"] for i in range(JOURNAL_CANDIDATE_COUNT)]
+            ok, msg = _save_candidates(selected_date_str, codes)
+            if not ok:
+                message.error(msg)
+                return False
+            st.rerun()
+
+        if reset:
+            for key in list(st.session_state):
+                if key.startswith("journal_candidate_code_"):
+                    del st.session_state[key]
+            ok, msg = _clear_candidates(selected_date_str)
+            if not ok:
+                message.error(msg)
+                return False
+            st.rerun()
+
+    else:
+        st.write("対象日のデータはまだありません。")
+
+
+def _get_existing_candidates(selected_date_str):
+    conn = get_connection()
+    try:
+        df = pd.read_sql_query(
+            """
+            SELECT
+                c.stock_code,
+                COALESCE(m.stock_name, c.stock_code) AS stock_name,
+                c.created_at
+            FROM journal_vote_candidate c
+            LEFT JOIN stock_master m ON c.stock_code = m.stock_code
+            WHERE c.vote_date = ?
+            ORDER BY c.id
+            """,
+            conn,
+            params=(selected_date_str,),
+        )
+        return df
+    finally:
+        conn.close()
+
+
+def _clear_candidates(selected_date_str):
+    conn = get_connection()
+    try:
+        c = conn.cursor()
+        c.execute(
+            "DELETE FROM journal_vote_candidate WHERE vote_date = ?",
+            (selected_date_str,),
+        )
+        conn.commit()
+        return True, "銘柄コードを初期値に戻しました。"
+
+    except Exception as e:
+        return False, f"初期値に戻す際にエラーが発生しました: {str(e)}"
+
+    finally:
+        conn.close()
+
+
+def _save_candidates(selected_date_str, codes):
+    normalized_codes = [code.strip() for code in codes if code and code.strip()]
+    message = ""
+
+    if len(normalized_codes) == 0:
+        return False, "銘柄コードを1件以上入力してください。"
+
+    if len(normalized_codes) > JOURNAL_CANDIDATE_COUNT:
+        return False, f"銘柄コードは最大{JOURNAL_CANDIDATE_COUNT}件です。"
+
+    invalid_codes = [code for code in normalized_codes if not re.match(r'^[A-Z0-9.]+$', code)]
+    if invalid_codes:
+        message = f"以下の銘柄コードが不正です: {', '.join(invalid_codes)}"
+        return False, message
+
+    conn = get_connection()
+    try:
+        c = conn.cursor()
+        now = pd.Timestamp.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        c.execute(
+            "DELETE FROM journal_vote_candidate WHERE vote_date = ?",
+            (selected_date_str,),
+        )
+
+        for code in normalized_codes:
+            c.execute(
+                """
+                INSERT INTO journal_vote_candidate (
+                    vote_date, stock_code, created_at
+                ) VALUES (?, ?, ?)
+                """,
+                (selected_date_str, code, now),
+            )
+
+        conn.commit()
+        return True, "銘柄コードを登録しました。"
+
+    finally:
+        conn.close()

--- a/pages/journal_vote_feedback.py
+++ b/pages/journal_vote_feedback.py
@@ -1,0 +1,121 @@
+import base64
+import pandas as pd
+import streamlit as st
+
+from datetime import datetime, timedelta
+from utils.db import get_connection
+from utils.common import TEACHER_LOGIN_TIME_MINUTES, decrypt_string
+
+
+def show(selected_date):
+    selected_date_str = selected_date.strftime("%Y-%m-%d")
+
+    st.title("ジャーナリング Mr.Kフィードバック参照")
+    st.write(f"【対象日】{selected_date_str}")
+
+    ## 暗号化キー確認
+    if not "JOURNAL_ENCRYPTION_KEY" in st.secrets:
+        st.error("暗号化キーが設定されていません。")
+        return False
+    JOURNAL_ENCRYPTION_KEY = base64.b64decode(st.secrets["JOURNAL_ENCRYPTION_KEY"])
+
+    ## 簡易ログインフォーム
+    ## https://www.chatwork.com/#!rid379516146-2138915098071539712
+    if not st.session_state.get("teacher_authenticated", False):
+        ## ログイン実施
+        login_flag = _teacher_login()
+        if not login_flag:
+            st.session_state.pop("teacher_authenticated", None)
+            st.session_state.pop("teacher_login_time", None)
+            return
+
+        ## ログイン成功
+        st.session_state["teacher_authenticated"] = True
+        st.session_state["teacher_login_time"] = datetime.now()
+        st.info("ログイン成功")
+        st.rerun()
+
+    ## ログイン成功後、フィードバック一覧を表示させる
+    feedback_detail_df = _get_feedback_detail(selected_date_str, JOURNAL_ENCRYPTION_KEY)
+    if feedback_detail_df.empty:
+        st.write("対象日のデータはありません。")
+        if st.button("ログアウト"):
+            st.session_state.pop("teacher_authenticated", None)
+            st.session_state.pop("teacher_login_time", None)
+            st.rerun()
+        return
+
+    col1, col2 = st.columns(2)
+    with col1:
+        ## 先生向け閲覧用CSV。自由記述の文字化け防止のためUTF-8 BOM付きで出力
+        csv = feedback_detail_df.to_csv(index=False, header=["回答番号", "投票日", "フィードバック内容"], encoding="utf-8-sig")
+        st.download_button(label="CSVダウンロード", data=csv, file_name=f"journal_feedback_{selected_date_str}.csv", mime="text/csv")
+
+    with col2:
+        if st.button("ログアウト"):
+            st.session_state.pop("teacher_authenticated", None)
+            st.session_state.pop("teacher_login_time", None)
+            st.rerun()
+
+
+    st.subheader("フィードバック一覧")
+    st.dataframe(
+        feedback_detail_df,
+        use_container_width=True,
+        hide_index=True,
+        column_config={"vote_journal_id": "回答番号", "vote_date": "投票日", "teacher_feedback": "フィードバック内容"}
+    )
+
+def _get_feedback_detail(selected_date_str, JOURNAL_ENCRYPTION_KEY):
+    conn = get_connection()
+    try:
+        df = pd.read_sql_query(
+            """
+            SELECT
+			    vote_journal_id,
+                vote_date,
+                teacher_feedback
+              FROM journal_vote_feedback
+              WHERE vote_date = ?
+                AND teacher_feedback IS NOT NULL
+                AND teacher_feedback != ''
+              ORDER BY vote_journal_id ASC
+            """,
+            conn,
+            params=(selected_date_str,),
+        )
+
+        ## フィードバック復号化
+        df["teacher_feedback"] = df["teacher_feedback"].apply(lambda x: decrypt_string(x, JOURNAL_ENCRYPTION_KEY))
+
+        return df
+    finally:
+        conn.close()
+
+
+def _teacher_login():
+    ## 初期設定（環境変数）があるか確認
+    if not "JORUNAL_TEACHER_PASSWORD" in st.secrets:
+        st.error("講師用パスワードが設定されていません。")
+        return False
+    JORUNAL_TEACHER_PASSWORD = st.secrets["JORUNAL_TEACHER_PASSWORD"]
+
+    ## ログイン期限
+    if st.session_state.get("teacher_login_time"):
+        last_login_time = st.session_state["teacher_login_time"]
+        if datetime.now() - last_login_time > timedelta(minutes=TEACHER_LOGIN_TIME_MINUTES):
+            st.warning("ログイン有効期限が切れました。再度ログインしてください。")
+            return False
+
+    with st.form("teacher_login_form"):
+        password = st.text_input("パスワード", type="password")
+        submitted = st.form_submit_button("ログイン")
+        if submitted:
+            if password == JORUNAL_TEACHER_PASSWORD:
+                return True
+            st.error(
+                "ログインに失敗しました。"
+                "パスワードを確認してください。"
+            )
+
+    return False

--- a/pages/journal_vote_history.py
+++ b/pages/journal_vote_history.py
@@ -1,0 +1,142 @@
+import base64
+import pandas as pd
+import streamlit as st
+
+from utils.db import get_connection
+from utils.common import decrypt_string, get_journal_vote_uuid, JOURNAL_SCORE_OPTIONS, WAVE_POSITION_OPTIONS, BASELINE_DIRECTION_OPTIONS, VOLATILITY_SCORE_OPTIONS, EXCEPTION_OPTIONS, LEADER_EXISTS_OPTIONS, MARKET_STATE_SCORE_OPTIONS, CONFIDENCE_SCORE_OPTIONS, FEELING_SCORE_OPTIONS
+
+def show(selected_date):
+    selected_date_str = selected_date.strftime("%Y-%m-%d")
+
+    st.title("ジャーナリング 回答参照")
+    st.write(f"【対象日】{selected_date_str}")
+
+    ## 暗号化キー確認
+    if not "JOURNAL_ENCRYPTION_KEY" in st.secrets:
+        st.error("暗号化キーが設定されていません。")
+        return False
+    JOURNAL_ENCRYPTION_KEY = base64.b64decode(st.secrets["JOURNAL_ENCRYPTION_KEY"])
+
+    uuid = get_journal_vote_uuid()
+    if uuid is None:
+        st.error("Cookieが無効、またはプライベートブラウズの場合は表示できません。")
+        return
+
+    journals = _get_journals(uuid, selected_date_str)
+    if journals.empty:
+        st.write("対象日の回答が見つかりませんでした。")
+        return
+
+    st.info("対象日の回答は以下の通りです。")
+    for _, journal in journals.iterrows():
+        votes = _get_votes(journal["id"], selected_date_str)
+        st.write("### 銘柄回答")
+        for _, vote in votes.iterrows():
+            st.write(f"#### {vote['stock_code']} {vote['stock_name']}")
+
+            col1, col2 = st.columns(2)
+            with col1:
+                st.write(f"直近10本の規律可能性: {JOURNAL_SCORE_OPTIONS.get(vote['score'], vote['score'])}")
+                st.write(f"波の位置: {WAVE_POSITION_OPTIONS.get(vote['wave_position'], vote['wave_position'])}")
+                st.write(f"ベースラインの方向性: {BASELINE_DIRECTION_OPTIONS.get(vote['baseline_direction'], vote['baseline_direction'])}")
+
+            with col2:
+                st.write(f"ボラティリティ: {VOLATILITY_SCORE_OPTIONS.get(vote['volatility'], vote['volatility'])}")
+                st.write(f"例外判断: {EXCEPTION_OPTIONS.get(vote['exception_needed'], vote['exception_needed'])}")
+            if vote["exception_reason"]:
+                st.write(f"例外理由: {vote['exception_reason']}")
+            st.divider()
+
+        st.write("### 自分の状態")
+        st.write(f"回答番号: {journal['id']}")
+        col1, col2 = st.columns(2)
+        with col1:
+            st.write(f"相場状態: {MARKET_STATE_SCORE_OPTIONS.get(journal['market_state'], journal['market_state'])}")
+            st.write(f"自信度: {CONFIDENCE_SCORE_OPTIONS.get(journal['confidence'], journal['confidence'])}")
+            st.write(f"気持ち: {FEELING_SCORE_OPTIONS.get(journal['feeling'], journal['feeling'])}")
+            teacher_feedback = _get_teacher_feedback(journal['id'], selected_date_str, JOURNAL_ENCRYPTION_KEY)
+            if not teacher_feedback.empty:
+                st.write(f"Mr.Kへの突っ込み: {teacher_feedback.iloc[0]['teacher_feedback']}")
+
+        with col2:
+            st.write(f"ポジション量: {journal['position_ratio']}%")
+            st.write(f"先導株の有無: {LEADER_EXISTS_OPTIONS.get(journal['leader_exists'], journal['leader_exists'])}")
+            if journal["leader_exists"] == 1:
+                st.write(f"先導株の銘柄コードまたは名称: {journal['leader_name_or_code']}")
+
+
+def _get_journals(uuid, selected_date_str):
+    conn = get_connection()
+
+    try:
+        return pd.read_sql_query(
+            """
+            SELECT
+                id,
+                vote_date,
+                market_state,
+                confidence,
+                feeling,
+                position_ratio,
+                leader_exists,
+                leader_name_or_code
+            FROM journal_vote_base
+            WHERE uuid = ? AND vote_date = ?
+            ORDER BY id ASC
+            """,
+            conn,
+            params=(uuid, selected_date_str)
+        )
+
+    finally:
+        conn.close()
+
+
+def _get_votes(journal_id, selected_date_str):
+    conn = get_connection()
+    try:
+        return pd.read_sql_query(
+            """
+            SELECT
+                v.id,
+                v.stock_code,
+                COALESCE(m.stock_name, v.stock_code) AS stock_name,
+                v.score,
+                v.wave_position,
+                v.baseline_direction,
+                v.volatility,
+                v.exception_needed,
+                v.exception_reason
+            FROM journal_vote v
+            LEFT JOIN stock_master m
+                ON v.stock_code = m.stock_code
+            WHERE v.vote_journal_id = ? AND v.vote_date = ?
+            ORDER BY v.id
+            """,
+            conn,
+            params=(journal_id, selected_date_str)
+        )
+
+    finally:
+        conn.close()
+
+
+def _get_teacher_feedback(journal_id, selected_date_str, JOURNAL_ENCRYPTION_KEY):
+    conn = get_connection()
+    try:
+        df = pd.read_sql_query(
+            """
+            SELECT
+                teacher_feedback
+            FROM journal_vote_feedback
+            WHERE vote_journal_id = ? AND vote_date = ?
+            """,
+            conn,
+            params=(journal_id, selected_date_str)
+        )
+        ## フィードバック復号化
+        df["teacher_feedback"] = df["teacher_feedback"].apply(lambda x: decrypt_string(x, JOURNAL_ENCRYPTION_KEY))
+        return df
+
+    finally:
+        conn.close()

--- a/pages/journal_vote_result.py
+++ b/pages/journal_vote_result.py
@@ -1,0 +1,271 @@
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+
+from collections import defaultdict
+from utils.db import get_connection
+from utils.common import JOURNAL_SCORE_OPTIONS, WAVE_POSITION_OPTIONS, BASELINE_DIRECTION_OPTIONS, VOLATILITY_SCORE_OPTIONS, EXCEPTION_OPTIONS, LEADER_EXISTS_OPTIONS, MARKET_STATE_SCORE_OPTIONS, CONFIDENCE_SCORE_OPTIONS, FEELING_SCORE_OPTIONS, POSITION_RATIO_MIN, POSITION_RATIO_MAX, POSITION_RATIO_GROUP
+
+def show(selected_date):
+    selected_date_str = selected_date.strftime("%Y-%m-%d")
+
+    st.title("ジャーナリング アンケート結果")
+    st.write(f"【対象日】{selected_date_str}")
+
+    journal_vote_base_df = _get_journal_base(selected_date_str)
+    if journal_vote_base_df.empty:
+        st.write("対象日のデータはまだありません。")
+        return
+    journal_vote_df = _get_journal_vote(selected_date_str)
+    journal_vote_base_summary_df = _get_journal_vote_base_summary(selected_date_str)
+    journal_vote_summary_df = _get_journal_vote_summary(selected_date_str)
+
+    st.subheader("集計結果")
+    st.metric("アンケート回答数", len(journal_vote_base_df))
+
+    st.markdown("---")
+    for _, row in journal_vote_summary_df.iterrows():
+        stock_code = row["stock_code"]
+        stock_name = row["stock_name"]
+        avg_stock_score = row["avg_stock_score"]
+        avg_stock_volatility = row["avg_stock_volatility"]
+        st.subheader(f"{stock_code} {stock_name}")
+
+        ## 投票内容
+        stock_votes = journal_vote_df[journal_vote_df["stock_code"] == stock_code].copy()
+
+        ## ① 直近10本の規律可能性
+        st.text("① 直近10本の規律可能性")
+        st.caption(f"平均: {avg_stock_score:.1f}/{next(reversed(JOURNAL_SCORE_OPTIONS))}")
+        _show_ratio_bar(stock_votes["score"], JOURNAL_SCORE_OPTIONS, f"{stock_code}_score")
+        groups = defaultdict(list)
+        for score, label in JOURNAL_SCORE_OPTIONS.items():
+            groups[label].append(score)
+            text = " / ".join(
+                f"{min(scores)}-{max(scores)}: {label}"
+                for label, scores in groups.items()
+            )
+        st.caption(text)
+
+        ## ② 大きな波の中の位置
+        st.text("② 大きな波の中の位置")
+        _show_ratio_bar(stock_votes["wave_position"], WAVE_POSITION_OPTIONS, f"{stock_code}_wave_position")
+
+        ## ③ ベースラインの方向性
+        st.text("③ ベースラインの方向性")
+        _show_ratio_bar(stock_votes["baseline_direction"], BASELINE_DIRECTION_OPTIONS, f"{stock_code}_baseline_direction")
+
+        ## ④ ボラティリティ
+        st.text("④ ボラティリティ")
+        st.caption(f"平均: {avg_stock_volatility:.1f}/{next(reversed(VOLATILITY_SCORE_OPTIONS))}")
+        _show_ratio_bar(stock_votes["volatility"], VOLATILITY_SCORE_OPTIONS, f"{stock_code}_volatility")
+        st.caption(" / ".join(f"{k}: {v}" for k, v in VOLATILITY_SCORE_OPTIONS.items()))
+
+        ## ⑤ 例外的な判断が必要／不要
+        st.text("⑤ 例外的な判断が必要／不要")
+        _show_ratio_bar(stock_votes["exception_needed"], EXCEPTION_OPTIONS, f"{stock_code}_exception_needed")
+
+        ## ⑥ 例外的な判断が必要な場合の理由
+        st.text("⑥ 例外的な判断が必要な場合の理由")
+        exception_votes = stock_votes[stock_votes["exception_needed"] == 1]
+        if exception_votes.empty:
+            st.write("例外的な判断が必要と回答した方はいません。")
+        else:
+            df = exception_votes[["exception_reason"]].copy()
+            df.index = range(1, len(df) + 1) ## コメント番号で、何番のコメントと一意にする
+            st.dataframe(df, column_config={"exception_reason": "理由"}, use_container_width=True)
+
+    ## 先導株の認識
+    st.markdown("---")
+    st.subheader("先導株の認識")
+    st.caption("先導株（または先導指数）はあるか")
+    _show_ratio_bar(journal_vote_base_df["leader_exists"], LEADER_EXISTS_OPTIONS, f"{stock_code}_leader_exists")
+
+    ## 先導株の銘柄コード／名称
+    journal_with_leader = journal_vote_base_df[journal_vote_base_df["leader_exists"] == 1]
+    if journal_with_leader.empty:
+        st.write("先導株（または先導指数）があると回答した方はいません。")
+    else:
+        st.text("先導株（または先導指数）の銘柄コード／名称")
+        counts = (
+            journal_with_leader["leader_name_or_code"].value_counts().rename_axis("銘柄コード／名称").reset_index(name="件数")
+        )
+        # 列順を変更
+        counts = counts[["件数", "銘柄コード／名称"]]
+        st.dataframe(counts, hide_index=True, use_container_width=True)
+
+    st.markdown("---")
+    st.subheader("みんなの状態")
+    if journal_vote_base_df.empty:
+        st.info("みんなの状態 アンケートの記録がありません。")
+    else:
+        avg_market_state   = journal_vote_base_summary_df["avg_market_state"].iloc[0]
+        avg_confidence     = journal_vote_base_summary_df["avg_confidence"].iloc[0]
+        avg_feeling        = journal_vote_base_summary_df["avg_feeling"].iloc[0]
+        avg_position_ratio = journal_vote_base_summary_df["avg_position_ratio"].iloc[0]
+        display_journal_vote_base_df = journal_vote_base_df.copy()
+
+        ## 今の相場は
+        st.text("今の相場は")
+        st.caption(f"平均: {avg_market_state:.1f}/{next(reversed(MARKET_STATE_SCORE_OPTIONS))}")
+        _show_ratio_bar(display_journal_vote_base_df["market_state"], MARKET_STATE_SCORE_OPTIONS, f"market_state")
+        st.caption(" / ".join(f"{k}: {v}" for k, v in MARKET_STATE_SCORE_OPTIONS.items()))
+
+        ## 自分の状態はけ
+        st.text("自分の状態は")
+        st.caption(f"平均: {avg_confidence:.1f}/{next(reversed(CONFIDENCE_SCORE_OPTIONS))}")
+        _show_ratio_bar(display_journal_vote_base_df["confidence"], CONFIDENCE_SCORE_OPTIONS, f"confidence")
+        st.caption(" / ".join(f"{k}: {v}" for k, v in CONFIDENCE_SCORE_OPTIONS.items()))
+
+        ## 気持ちは
+        st.text("気持ちは")
+        st.caption(f"平均: {avg_feeling:.1f}/{next(reversed(FEELING_SCORE_OPTIONS))}")
+        _show_ratio_bar(display_journal_vote_base_df["feeling"], FEELING_SCORE_OPTIONS, f"feeling")
+        st.caption(" / ".join(f"{k}: {v}" for k, v in FEELING_SCORE_OPTIONS.items()))
+
+        ## 今のポジション量
+        st.text("今のポジション量")
+        st.caption(f"平均: {avg_position_ratio:.1f}%")
+
+        grouped_position_ratio = (
+            (display_journal_vote_base_df["position_ratio"] // POSITION_RATIO_GROUP) * POSITION_RATIO_GROUP
+        )
+        position_ratio_options = {
+            start: f"{start}～{min(start + POSITION_RATIO_GROUP - 10, POSITION_RATIO_MAX)}%"
+            for start in range(POSITION_RATIO_MIN, POSITION_RATIO_MAX + 1, POSITION_RATIO_GROUP,)
+        }
+        _show_ratio_bar(grouped_position_ratio, position_ratio_options, f"position_ratio")
+
+
+def _get_journal_vote_base_summary(selected_date_str):
+    conn = get_connection()
+    try:
+        df = pd.read_sql_query(
+            """
+            SELECT
+                AVG(j.market_state) AS avg_market_state,
+                AVG(j.confidence) AS avg_confidence,
+                AVG(j.feeling) AS avg_feeling,
+                AVG(j.position_ratio) AS avg_position_ratio
+            FROM journal_vote_base j
+            WHERE j.vote_date = ?
+            ORDER BY j.id ASC
+            """,
+            conn,
+            params=(selected_date_str,),
+        )
+        return df
+    finally:
+        conn.close()
+
+
+def _get_journal_base(selected_date_str):
+    conn = get_connection()
+    try:
+        df = pd.read_sql_query(
+            """
+            SELECT
+                j.id AS journal_id,
+                j.vote_date,
+                j.questionnaire_version,
+                j.market_state,
+                j.confidence,
+                j.feeling,
+                j.position_ratio,
+                j.leader_exists,
+                j.leader_name_or_code,
+                j.created_at
+            FROM journal_vote_base j
+            WHERE j.vote_date = ?
+            ORDER BY j.id ASC
+            """,
+            conn,
+            params=(selected_date_str,),
+        )
+        return df
+    finally:
+        conn.close()
+
+
+def _get_journal_vote_summary(selected_date_str):
+    conn = get_connection()
+    try:
+        df = pd.read_sql_query(
+            """
+            SELECT
+                r.stock_code,
+                COALESCE(m.stock_name, r.stock_code) AS stock_name,
+                AVG(r.score) AS avg_stock_score,
+                AVG(r.volatility) AS avg_stock_volatility
+            FROM journal_vote r
+            LEFT JOIN stock_master m ON r.stock_code = m.stock_code
+            WHERE r.vote_date = ?
+            GROUP BY r.stock_code
+            ORDER BY r.id ASC
+            """,
+            conn,
+            params=(selected_date_str,),
+        )
+        return df
+    finally:
+        conn.close()
+
+
+def _get_journal_vote(selected_date_str):
+    conn = get_connection()
+    try:
+        df = pd.read_sql_query(
+            """
+            SELECT
+                r.stock_code,
+                COALESCE(m.stock_name, r.stock_code) AS stock_name,
+                r.score,
+                r.wave_position,
+                r.baseline_direction,
+                r.volatility,
+                r.exception_needed,
+                r.exception_reason
+            FROM journal_vote r
+            LEFT JOIN stock_master m ON r.stock_code = m.stock_code
+            WHERE r.vote_date = ?
+            ORDER BY r.stock_code ASC
+            """,
+            conn,
+            params=(selected_date_str,),
+        )
+        return df
+    finally:
+        conn.close()
+
+
+def _show_ratio_bar(series, options, key=None):
+    count = series.value_counts().sort_index()
+    labels = [options.get(x, x) for x in count.index]
+    percent = count / count.sum() * 100
+
+    fig = go.Figure()
+
+    for x, label, p, c in zip(count.index, labels, percent, count):
+        fig.add_bar(
+            x=[p],
+            y=[""],
+            orientation="h",
+            name=label,
+            text=f"{label}<br>({p:.1f}%)",
+            textposition="inside",
+            insidetextanchor="middle",
+            textfont_size=16,
+            hovertemplate=(f"{x}: {label}<br>{c}票 ({p:.1f}%)<extra></extra>"
+    ),
+        )
+
+    fig.update_layout(
+        barmode="stack",
+        xaxis=dict(range=[0, 100], visible=False),
+        yaxis=dict(showticklabels=False),
+        height=120,
+        margin=dict(l=0, r=0, t=0, b=0),
+        showlegend=False
+    )
+    st.plotly_chart(fig, use_container_width=True, key=key)

--- a/pages/survey_chatwork_post.py
+++ b/pages/survey_chatwork_post.py
@@ -50,7 +50,7 @@ def show(selected_date):
     selected_date_str = selected_date.strftime("%Y-%m-%d")
     date_str = selected_date.strftime("%Y%m%d")
 
-    st.title("銘柄投票 ChatWork投稿")
+    st.title("銘柄コード登録結果 ChatWork投稿")
     st.write(f"【対象日】{selected_date_str}")
 
     # 銘柄コード登録結果を取得
@@ -59,7 +59,7 @@ def show(selected_date):
     if not results:
         st.warning("対象日の銘柄コード登録がありません。銘柄コード登録がある日付を選択してください。")
         st.markdown(
-            f'<a href="./?page=vote&date={date_str}" target="_self">← 銘柄投票ページに戻る</a>',
+            f'<a href="./?page=survey&date={date_str}" target="_self">← 銘柄コード登録ページに戻る</a>',
             unsafe_allow_html=True
         )
         return
@@ -85,7 +85,7 @@ def show(selected_date):
 
     if not chatwork.is_logged_in():
         st.info("ChatWorkにログインして投稿してください。")
-        chatwork.show_login_button(return_page="vote_chatwork_post", return_date=date_str)
+        chatwork.show_login_button(return_page="survey_chatwork_post", return_date=date_str)
     else:
         try:
             if not chatwork.is_room_member():
@@ -117,6 +117,6 @@ def show(selected_date):
 
     st.markdown("---")
     st.markdown(
-        f'<a href="./?page=vote&date={date_str}" target="_self">← 銘柄投票ページに戻る</a>',
+        f'<a href="./?page=survey&date={date_str}" target="_self">← 銘柄コード登録ページに戻る</a>',
         unsafe_allow_html=True
     )

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,5 +1,10 @@
-from datetime import datetime
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
+import base64
+import os
+import streamlit as st
+import uuid
 import yfinance as yf
 from utils.db import get_connection
 
@@ -7,6 +12,24 @@ DUMMY_STOCK_CODE = "0000"  # 銘柄発掘、投票時の「該当なし」のダ
 MAX_SETS = 7               # 銘柄発掘アンケートの入力セット数
 MAX_VOTE_SELECTION = 10    # 集計ページでのチェックボックスの最大選択数
 STOCKS_PER_PAGE = 100      # 銘柄マスタ一覧の1ページあたりの表示件数
+JOURNAL_CANDIDATE_COUNT = 5 # ジャーナリング投票の銘柄候補数
+
+## ジャーナリング投票のアンケートの選択肢とスコアの範囲
+QUESTIONNAIRE_VERSION = 1 ## 回答バージョン
+JOURNAL_SCORE_OPTIONS = { 1: "ランダム", 2: "ランダム", 3: "ややランダム", 4: "ややランダム", 5: "中間", 6: "中間", 7: "やや規律的", 8: "やや規律的", 9: "規律正しい", 10: "規律正しい" } ## 規律可能性のスコアラベル
+WAVE_POSITION_OPTIONS = { "bottom": "初動", "middle": "中盤", "top": "終盤", "unknown": "不明" } ## 大きな波の中の位置の選択肢
+BASELINE_DIRECTION_OPTIONS = { "down": "下落", "unknown":"方向性不明確", "up": "上昇" } ## ベースラインの方向性の選択肢
+VOLATILITY_SCORE_OPTIONS = { 1: "非常に小さい", 2: "小さい", 3: "中間", 4: "大きい", 5: "非常に大きい" } ## ボラティリティのスコアラベル
+EXCEPTION_OPTIONS = { 0: "不要", 1: "必要" } ## 例外的な判断の選択肢
+LEADER_EXISTS_OPTIONS = { 0: "ない", 1: "ある"} ## 先導株の選択肢
+MARKET_STATE_SCORE_OPTIONS = { 1: "簡単", 2: "やや簡単", 3: "中間", 4: "やや難しい", 5: "難しい" } ## 相場のスコアラベル
+CONFIDENCE_SCORE_OPTIONS = { 1: "自信がない", 2: "やや自信がない", 3: "中間", 4: "やや自信がある", 5: "全能感がある" } ## 自信度スコアラベル
+FEELING_SCORE_OPTIONS = { 1: "不安", 2: "やや不安", 3: "中間", 4: "やや安心", 5: "安心している" } ## 自信度スコアラベル
+POSITION_RATIO_MIN = 0     ## ポジション量のスコアの最小値
+POSITION_RATIO_MAX = 150   ## ポジション量のスコアの最大値
+POSITION_RATIO_GROUP = 30  ## ポジション量の表示区切り
+TEACHER_LOGIN_TIME_MINUTES = 60   ## 講師フィードバックのログイン有効時間（分）
+JOURNAL_COOKIE_EXPIRE_DAYS = 730  ## ジャーナリング投票結果参照のためのCookie期限 (日)
 
 def get_ticker(stock_code):
     """
@@ -124,3 +147,45 @@ def get_stock_name(stock_code):
     conn.close()
     # どちらも見つからない場合は銘柄コードを返す
     return stock_code
+
+
+## 文字列の暗号化
+def encrypt_string(plaintext, JOURNAL_ENCRYPTION_KEY):
+    aesgcm = AESGCM(JOURNAL_ENCRYPTION_KEY)
+    nonce = os.urandom(12)
+    ciphertext = aesgcm.encrypt(nonce, plaintext.encode(), None)
+    return base64.b64encode(nonce + ciphertext).decode()
+
+
+## 文字列の復号化
+def decrypt_string(encrypted_text, JOURNAL_ENCRYPTION_KEY):
+    aesgcm = AESGCM(JOURNAL_ENCRYPTION_KEY)
+    raw = base64.b64decode(encrypted_text)
+
+    nonce = raw[:12]
+    ciphertext = raw[12:]
+
+    return aesgcm.decrypt(nonce, ciphertext, None).decode()
+
+
+## ジャーナリング時のuuid取得
+def get_journal_vote_uuid():
+    ## 投票画面アクセス毎にUUIDを取得する
+    ## 久しぶりのアクセスで期限切れにならないように都度更新する。
+    ## CookieManagerでアクセスする st.rerun() によってパフォーマンス劣化するため、JavaScriptでCookie更新する.
+    user_id = st.context.cookies.get("journal_vote_uuid")
+    if user_id is None:
+        user_id = str(uuid.uuid4())
+
+    ## 新規登録 + 現行UUIDの期限更新
+    expires = datetime.now() + timedelta(days=JOURNAL_COOKIE_EXPIRE_DAYS)
+    max_age = JOURNAL_COOKIE_EXPIRE_DAYS * 24 * 60 * 60
+    st.components.v1.html(
+        f"""
+        <script>
+        document.cookie = "{"journal_vote_uuid"}={user_id}; Max-Age={max_age}; Path=/; SameSite=Lax";
+        </script>
+        """,
+        height=0,
+    )
+    return user_id

--- a/utils/db.py
+++ b/utils/db.py
@@ -99,6 +99,83 @@ def init_db():
     """)
     c.execute("CREATE INDEX IF NOT EXISTS idx_analysis_date_code ON analysis_results (analysis_date, stock_code);")
 
+
+    # ジャーナリング投票の候補銘柄を保存するテーブル
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS journal_vote_candidate (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            vote_date TEXT NOT NULL,
+            stock_code TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(vote_date, stock_code)
+        )
+        """
+    )
+    c.execute("CREATE INDEX IF NOT EXISTS idx_journal_vote_candidate_date ON journal_vote_candidate (vote_date);")
+
+
+    # ジャーナリング投票の共通アンケート記録を保存するテーブル
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS journal_vote_base (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            vote_date TEXT NOT NULL,
+            uuid TEXT NOT NULL,
+            questionnaire_version INTEGER NOT NULL DEFAULT 1,
+            market_state INTEGER NOT NULL,
+            confidence INTEGER NOT NULL,
+            feeling INTEGER NOT NULL,
+            position_ratio INTEGER NOT NULL,
+            leader_exists INTEGER NOT NULL,
+            leader_name_or_code TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    c.execute("CREATE INDEX IF NOT EXISTS idx_journal_vote_base_date ON journal_vote_base (vote_date);")
+
+
+    # ジャーナリング投票の入力を保存するテーブル
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS journal_vote (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            vote_date TEXT NOT NULL,
+            vote_journal_id INTEGER NOT NULL,
+            stock_code TEXT NOT NULL,
+            score INTEGER NOT NULL,
+            wave_position TEXT NOT NULL,
+            baseline_direction TEXT NOT NULL,
+            volatility INTEGER NOT NULL,
+            exception_needed INTEGER NOT NULL,
+            exception_reason TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(vote_date, vote_journal_id, stock_code)
+        )
+        """
+    )
+    c.execute("CREATE INDEX IF NOT EXISTS idx_journal_vote_date ON journal_vote (vote_date);")
+    c.execute("CREATE INDEX IF NOT EXISTS idx_journal_vote_date_code ON journal_vote (vote_date, stock_code);")
+
+
+    # ジャーナリング 講師へのフィードバック
+    # カラム暗号化を行うため別テーブルへ切り出し。
+    # 復号化キーをロストして復号化出来なくなった際に、ジャーナリングアンケートの投票結果へ影響を与えない様にする。
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS journal_vote_feedback (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            vote_date TEXT NOT NULL,
+            vote_journal_id INTEGER NOT NULL,
+            teacher_feedback TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(vote_date, vote_journal_id)
+        )
+        """
+    )
+    c.execute("CREATE INDEX IF NOT EXISTS idx_journal_vote_feedback_date ON journal_vote_feedback (vote_date);")
+
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
Closes #42

## 概要

銘柄投票時のコンディションを記録できるジャーナリング機能を追加しました。
2026.8.11現在、Google Apps Scriptでアンケートフォームを利用して対応中のため、様子を見つつ、アンケート日数が増えてきてシステム化が必要になった際にこのPRが役立つ事を想定しています。

### 変更内容

- 投票時にジャーナリングアンケートへ回答可能
- 投票日毎にジャーナリングアンケートの集計結果を参照可能
- 自身が回答した内容を確認可能
→ 個人情報の取得を回避するため、ブラウザ毎にuuidをcookieに持ちキーにして参照させる。
- ジャーナリングアンケート内の `Mr.Kへのフィードバック回答` を専用画面化させる。
→ コミュニティメンバー → 講師へのフィードバック内容となるため他のメンバーが閲覧できないように暗号化を実施。
- 左メニューが増えたことに伴い、左メニューの表示順序を整理しました。

投票した時の「その時、自分がどういう状態だったか」を後から振り返れるようにしています。

## 注意
このPRを導入した場合以下のSecret ( `secrets.toml` )への追加が必要となります。
デプロイ時に環境設定をお願いします。

|項目|種類|説明|
|----|----|----|
| JORUNAL_TEACHER_PASSWORD | string |  `⑦-4 ジャーナリング Mr.Kフィードバック参照` ログインパスワード。|
| JOURNAL_ENCRYPTION_KEY | string | Mr.Kへのフィードバックコメントの暗号化・復号化キー(AES256-GCM)。以下のコマンドで生成した文字列。<br>```$ openssl rand -base64 32```<br>★この暗号化キーを変更・紛失すると、既存のフィードバックコメントを復号できなくなります。<br>鍵のバックアップを含め、取り扱いには十分注意してください。|


## 動作確認
### ⑦ ジャーナリング 銘柄登録
(1) 初期画面
銘柄投票の上位3銘柄が「銘柄コード1〜3」へ入ります。
(2) 「銘柄コードを登録」で正式なジャーナリング対象銘柄として確定します。
画面は3銘柄ですが、1〜2銘柄へ減らした形での登録も可能。
<img width="620" height="896" alt="image" src="https://github.com/user-attachments/assets/ef4004d5-a219-4d6a-8354-16a246dfd25f" />
(3) 「初期値に戻す」を押すと(1)の初期画面のように上位3銘柄を呼び出す仕組みです。


### ⑦-2 ジャーナリング アンケート
アンケートフォームは、Googleアンケートフォームと項目を合わせた形。
画面下の「投票」を押すことでアンケート回答をSubmitする方式。
<img width="756" height="985" alt="image" src="https://github.com/user-attachments/assets/2bae229a-b6a6-45f0-baf3-7129de3331a7" />
<img width="679" height="639" alt="image" src="https://github.com/user-attachments/assets/700049a3-df39-4f73-92be-76b960fe55e2" />


### ⑦-3 ジャーナリング アンケート結果
アンケート結果も、Googleフォームに合わせてあります。
<img width="751" height="972" alt="image" src="https://github.com/user-attachments/assets/77db5f6a-2640-4c23-9731-b09f73c7cb11" />
<img width="777" height="449" alt="image" src="https://github.com/user-attachments/assets/6e023497-2056-4751-896a-61642a06ea10" />
<img width="770" height="1047" alt="image" src="https://github.com/user-attachments/assets/94481ba7-5beb-4db0-91c4-0455d4a2cbbc" />


### ⑦-3 ジャーナリング 回答参照
自身がどの様に回答したかを表示する機能。
ブラウザ毎にcookieで持ったuuidを基に回答した内容を表示しています。
（メールアドレス等の個人情報の収集を避けるためです）
ブラウザが同じであれば回答を閲覧できますが、プライベートブラウジングやCookieを消した場合は閲覧できない簡易機能です。
<img width="749" height="845" alt="image" src="https://github.com/user-attachments/assets/5cb56424-8072-4610-9641-c2e3ad5dfe05" />


### ⑦-4 ジャーナリング Mr.Kフィードバック参照
(1) ログイン画面
認証OK, 認証NG (文字列誤り)を確認済
<img width="770" height="418" alt="image" src="https://github.com/user-attachments/assets/6a07f7c3-2b52-4e90-9adb-3573e01b15d7" />
(2) ログイン成功
フィードバック一覧が表示されることを確認。
<img width="729" height="439" alt="image" src="https://github.com/user-attachments/assets/649d3de4-8e84-4b3d-86b6-2a9512569973" />
(3) CSVダウンロード
CSVダウンロードボタンを押下後、CSVが出来る事を確認済み。
```
回答番号,投票日,フィードバック内容
3,2026-08-11,突っ込みテスト
5,2026-08-11,Chrome Devからの書き込みです。
```


### 左メニュー
(1) メニュー番号 7 番に「ジャーナリング機能」を新設しました。
銘柄投票とは毛色が異なるため末尾へ追加したイメージです。
(2) 併せて、銘柄コード登録後のChatwork投稿機能を2の銘柄投票下に置いていたのですが、機能を分類すると1の銘柄登録結果のアウトプットとなるため1版の結果出力の位置づけとして場所変えしました。
(3) 区切り線を入れて、「銘柄コード登録」「投票」など利用する機能毎に区切り線を入れました。
→ 銘柄登録結果のChatwork投稿メニューが
<img width="194" height="924" alt="image" src="https://github.com/user-attachments/assets/e3e0b12a-9892-40b8-9960-d9d2e1a925fd" />
